### PR TITLE
Added parse as an URL parameter

### DIFF
--- a/sgqlc/endpoint/http.py
+++ b/sgqlc/endpoint/http.py
@@ -25,6 +25,7 @@ import json
 import logging
 import urllib.error
 import urllib.request
+import urllib.parse
 
 from .base import BaseEndpoint
 
@@ -145,8 +146,9 @@ class HTTPEndpoint(BaseEndpoint):
 
         self.logger.debug('Query:\n%s', query)
 
+        target = f'{self.url}?query={urllib.parse.quote_plus(query)}'
         req = urllib.request.Request(
-            url=self.url, data=post_data, headers=headers)
+            url=target, data=post_data, headers=headers)
         try:
             with urllib.request.urlopen(req, timeout=timeout) as f:
                 body = f.read().decode('utf-8')


### PR DESCRIPTION
While running `python3 -m sgqlc.endpoint.http http://server.com/ '{ queryField }'` I was frequently getting the following problem:

> ERROR: GraphQL query failed with 1 errors
> {
>   "errors": [
>     {
>       "message": "Must provide query string."
>     }
>   ]
> }

I noticed that generally the GQL query seems to be passed as a URL parameter. This PR contains the solution to my problem above.