### PR TITLE
fixed TypeError when array path

### DIFF
--- a/sgqlc/endpoint/base.py
+++ b/sgqlc/endpoint/base.py
@@ -125,7 +125,7 @@ class BaseEndpoint:
         for i, error in enumerate(errors):
             paths = error.get('path')
             if paths:
-                paths = ' ' + '/'.join(paths)
+                paths = ' ' + '/'.join(str(path) for path in paths)
             else:
                 paths = ''
             self.logger.info('Error #{}{}:'.format(i, paths))


### PR DESCRIPTION
It may be TypeError when in  data['errors'] persists elements of array in the path  like: ['client', 'items', 0, 'products']
It will raise:
```   errors = data['errors']
        self.logger.error('GraphQL query failed with %s errors', len(errors))
        for i, error in enumerate(errors):
            paths = error.get('path')
            if paths:
>               paths = ' ' + '/'.join(paths)
E               TypeError: sequence item 3: expected str instance, int found
```