### PR TITLE
Allow datetime scalars to also be string

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[report]
+show_missing = True

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__
 /cover
 /.venv
 /.eggs
+.vscode

--- a/README.rst
+++ b/README.rst
@@ -419,3 +419,22 @@ Authors
 License
 -------
 `sgqlc` is licensed under the `ISC <https://opensource.org/licenses/ISC>`_.
+
+
+Getting started developing
+--------------------------
+
+You need to use `pipenv <https://pipenv.readthedocs.io/en/latest>`_.
+
+::
+
+    pipenv install --dev -e .
+    pipenv shell
+
+Run the tests:
+
+::
+
+    ./utils/git/pre-commit
+
+To integrate changes from another branch, please rebase instead of creating merge commits (`read more <https://git-scm.com/book/en/v2/Git-Branching-Rebasing>`_).

--- a/sgqlc/types/datetime.py
+++ b/sgqlc/types/datetime.py
@@ -158,7 +158,11 @@ class Time(Scalar):
 
     @classmethod
     def __to_json_value__(cls, value):
-        return None if value is None else value.isoformat()
+        if value is None:
+            return None
+        if isinstance(value, str):
+            return value
+        return value.isoformat()
 
 
 class Date(Scalar):
@@ -201,7 +205,11 @@ class Date(Scalar):
 
     @classmethod
     def __to_json_value__(cls, value):
-        return None if value is None else value.isoformat()
+        if value is None:
+            return None
+        if isinstance(value, str):
+            return value
+        return value.isoformat()
 
 
 class DateTime(Scalar):
@@ -276,7 +284,11 @@ class DateTime(Scalar):
 
     @classmethod
     def __to_json_value__(cls, value):
-        return None if value is None else value.isoformat()
+        if value is None:
+            return None
+        if isinstance(value, str):
+            return value
+        return value.isoformat()
 
 
 map_python_to_graphql.update({

--- a/sgqlc/types/datetime.py
+++ b/sgqlc/types/datetime.py
@@ -128,6 +128,9 @@ class Time(Scalar):
     >>> tzinfo = datetime.timezone.utc
     >>> Time.__to_json_value__(datetime.time(12, 34, 56, 0, tzinfo))
     '12:34:56+00:00'
+    >>> Time.__to_json_value__('12:34:56')
+    '12:34:56'
+    >>> Time.__to_json_value__(None)
 
     '''
 
@@ -185,6 +188,9 @@ class Date(Scalar):
 
     >>> Date.__to_json_value__(datetime.date(2018, 1, 2))
     '2018-01-02'
+    >>> Date.__to_json_value__('2018-01-02')
+    '2018-01-02'
+    >>> Date.__to_json_value__(None)
 
     '''
 
@@ -246,9 +252,13 @@ class DateTime(Scalar):
     >>> dt = datetime.datetime(2018, 1, 2, 12, 34, 56)
     >>> DateTime.__to_json_value__(dt)
     '2018-01-02T12:34:56'
+    >>> DateTime.__to_json_value__('2018-01-02T12:34:56')
+    '2018-01-02T12:34:56'
     >>> tzinfo = datetime.timezone.utc
     >>> DateTime.__to_json_value__(dt.replace(tzinfo=tzinfo))
     '2018-01-02T12:34:56+00:00'
+    >>> DateTime.__to_json_value__(None)
+
     '''
 
     _re_parse = re.compile(


### PR DESCRIPTION
I have this use-case where i need to do a requests that requires a `datetime` scalar, but I can only send it in as string, not as a `DateTime` object (due to some json signatures beforehand). I figured we might also allow datetime scalars to be sent as string, as sgqlc does with the other scalar types. This would definitely fix my issues :)

What do you think?