### PR TITLE
Remove non-standard relay field totalCount

### DIFF
--- a/examples/github/github-agile-dashboard.py
+++ b/examples/github/github-agile-dashboard.py
@@ -147,7 +147,6 @@ def select_pull_requests(repo, labels=(), states=(),
     nodes.assignees(first=100).nodes.login()
 
     reviews = nodes.reviews(first=100)
-    reviews.total_count()
     reviews.nodes.author.login()
     reviews.nodes.__fields__(
         body_text=True,

--- a/sgqlc/types/relay.py
+++ b/sgqlc/types/relay.py
@@ -218,7 +218,7 @@ MyEdge(node=NodeBasedType(id='4444', a_int=4), cursor='cursor-4')
     "hasNextPage": false,
     "hasPreviousPage": false,
     "startCursor": "cursor-1"
-  },
+  }
 }
 
 When merging, the receiver connection can be empty:
@@ -295,7 +295,7 @@ MyEdge(node=NodeBasedType(id='4444', a_int=4), cursor='cursor-4')
     "hasNextPage": false,
     "hasPreviousPage": false,
     "startCursor": "cursor-1"
-  },
+  }
 }
 
 


### PR DESCRIPTION
As stated in #39 we need to remove this field, otherwise when using `__field__()` we get auto completed selections requesting a field that is not mandatory in the graphql implementation.