### PR TITLE
[Fix][profusion/sgqlc#35] Don't error when populating fields from casted list

### DIFF
--- a/sgqlc/types/__init__.py
+++ b/sgqlc/types/__init__.py
@@ -1627,7 +1627,14 @@ class ContainerType(BaseTypeWithTypename, metaclass=ContainerTypeMeta):
             return ftype
 
         graphql_name = field.graphql_name
-        tname = json_data.get(graphql_name, {}).get('__typename')
+        try:
+            tname = json_data.get(graphql_name, {}).get('__typename')
+        except AttributeError:
+            # The selection returned something other than a dict, e.g. a list.
+            # Nothing to worry about, it just means this object doesn't contain
+            # a typename.
+            tname = None
+
         if not tname:
             return ftype
 


### PR DESCRIPTION
When casting using `__as__`, we store the cast-to type in a `__casts__` list.
When constructing the response to a query, we check whether `__casts__` is
populated, and if so we attempt to retrieve the `__typename` field from the
JSON object in question. If that object is a list, it doesn't have fields so the
`get()` call fails.

For an example piece of failing code, see profusion/sgqlc#35.

This fix catches the `AttributeError` raised when the `get()` call fails, and
ignores it. The elements within the list will be separately cast to the correct
type recursively.