### PR TITLE
Implement synchronous websocket endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ __pycache__
 /.venv
 /.eggs
 .vscode
+.python-version
+.idea

--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,7 @@ name = "pypi"
 [packages]
 sgqlc = {editable = true,path = "."}
 graphql-core = "*"
+websocket-client = "==0.56.0"
 
 [dev-packages]
 "flake8" = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "774ca397579ad87fd3e94e583c2cac4104fd9f37e162a873fea8da5704caacb8"
+            "sha256": "759b23349152de45707c81f682dee56cc5bdf5df3d8f10321ed2a21634db4879"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -48,6 +48,14 @@
                 "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
             ],
             "version": "==1.12.0"
+        },
+        "websocket-client": {
+            "hashes": [
+                "sha256:1151d5fb3a62dc129164292e1227655e4bbc5dd5340a5165dfae61128ec50aa9",
+                "sha256:1fd5520878b68b84b5748bb30e592b10d0a91529d5383f74f4964e72b297fd3a"
+            ],
+            "index": "pypi",
+            "version": "==0.56.0"
         }
     },
     "develop": {

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ tests= sgqlc/__init__.py,
    sgqlc/types/relay.py,
    sgqlc/operation/__init__.py,
    tests/test-endpoint-http.py,
+   tests/test-endpoint-websocket.py,
    tests/test-introspection.py
 
 [build_sphinx]
@@ -47,3 +48,4 @@ exclude =
 # W503: old coding style (new PEP8 is enforced by W504)
 ignore = I801,RST304,N999,W503
 max-complexity = 10
+known-modules = websocket-client:[websocket]

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     license='ISCL',
     python_requires='>=3.6',
     requires=[],
-    install_requires=['graphql-core'],
+    install_requires=['graphql-core', 'websocket-client'],
     extras_require={
         'sphinx': ['sphinx'],
     },

--- a/sgqlc/endpoint/websocket.py
+++ b/sgqlc/endpoint/websocket.py
@@ -1,0 +1,105 @@
+from sgqlc.endpoint.base import BaseEndpoint
+import websocket
+import uuid
+import json
+
+
+class WebSocketEndpoint(BaseEndpoint):
+    '''
+    A synchronous websocket endpoint for graphql queries or subscriptions
+    '''
+    def __init__(self, url, **ws_options):
+        '''
+        :param url: ws:// or wss:// url to connect to
+        :type url: str
+
+        :param ws_options: options to pass to websocket.create_connection
+        :type ws_options: dict
+        '''
+        self.url = url
+        self.ws_options = ws_options
+
+    def __str__(self):
+        return '%s(url=%s, ws_options=%s)' % (
+            self.__class__.__name__, self.url, self.ws_options)
+
+    def __call__(self, query, variables=None, operation_name=None):
+        '''
+        Makes a single query over the websocket
+
+        :param query: the GraphQL query or mutation to execute. Note
+          that this is converted using ``bytes()``, thus one may pass
+          an object implementing ``__bytes__()`` method to return the
+          query, eventually in more compact form (no indentation, etc).
+        :type query: :class:`str` or :class:`bytes`.
+
+        :param variables: variables (dict) to use with
+          ``query``. This is only useful if the query or
+          mutation contains ``$variableName``.
+        :type variables: dict
+
+        :param operation_name: if more than one operation is listed in
+          ``query``, then it should specify the one to be executed.
+        :type operation_name: str
+
+        :return: generator of dicts with optional fields ``data`` containing
+          the GraphQL returned data as nested dict and ``errors`` with
+          an array of errors. Note that both ``data`` and ``errors`` may
+          be returned in each dict!
+          Will generate a single element for ``query`` operations,
+          where data lists are generally embedded within the result structure.
+          For ``subscription`` operations, will generate a dict for each
+          subscription notification.
+
+        :rtype: generator
+        '''
+        if isinstance(query, bytes):
+            query = query.decode('utf-8')
+        elif not isinstance(query, str):
+            # allows sgqlc.operation.Operation to be passed
+            # and generate compact representation of the queries
+            query = bytes(query).decode('utf-8')
+        ws = websocket.create_connection(self.url,
+                                         subprotocols=['graphql-ws'],
+                                         **self.ws_options)
+        try:
+            init_id = self.generate_id()
+            ws.send(json.dumps({'type': 'connection_init', 'id': init_id}))
+            response = json.loads(ws.recv())
+            if response['type'] != 'connection_ack':
+                raise ValueError(
+                    f'Unexpected {response["type"]} '
+                    f'when waiting for connection ack'
+                )
+            if response['id'] != init_id:
+                raise ValueError(
+                    f'Unexpected id {response["id"]} '
+                    f'when waiting for connection ack'
+                )
+
+            query_id = self.generate_id()
+            ws.send(json.dumps({'type': 'start',
+                                'id': query_id,
+                                'payload': {'query': query,
+                                            'variables': variables,
+                                            'operationName': operation_name}}))
+            response = json.loads(ws.recv())
+            while response['type'] != 'complete':
+                if response['id'] != query_id:
+                    raise ValueError(
+                        f'Unexpected id {response["id"]} '
+                        f'when waiting for query results'
+                    )
+                if response['type'] == 'data':
+                    yield response['payload']
+                else:
+                    raise ValueError(f'Unexpected message {response} '
+                                     f'when waiting for query results')
+                response = json.loads(ws.recv())
+
+        finally:
+            ws.close()
+
+    @staticmethod
+    def generate_id() -> str:
+        return str(uuid.uuid4())

--- a/tests/test-endpoint-websocket.py
+++ b/tests/test-endpoint-websocket.py
@@ -1,0 +1,277 @@
+import json
+import re
+from unittest.mock import patch, Mock
+
+from sgqlc.endpoint.websocket import WebSocketEndpoint
+from nose.tools import eq_
+
+from sgqlc.operation import Operation
+from sgqlc.types import Schema, Type
+
+test_url = 'ws://localhost:12345/graphql'
+endpoint = WebSocketEndpoint(test_url)
+endpoint.generate_id = lambda: '123'
+
+
+def test_endpoint_str():
+    'Test websocket str() implementation'
+    eq_(str(endpoint),
+        'WebSocketEndpoint('
+        + 'url={}'.format(test_url)
+        + ', ws_options={})',
+        )
+
+
+def test_endpoint_id():
+    'Test websocket uuid generation'
+    generated_id = WebSocketEndpoint('').generate_id()
+    eq_(
+        re.match(
+            '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}',
+            generated_id
+        ) is not None,
+        True
+    )
+
+
+@patch('sgqlc.endpoint.websocket.websocket')
+def test_basic_query(mock_websocket):
+    'Test websocket endpoint against simple query'
+    mock_connection = Mock()
+    mock_websocket.create_connection.return_value = mock_connection
+    mock_connection.recv.side_effect = [
+        """
+        {
+            "type": "connection_ack",
+            "id": "123"
+        }
+        """,
+        """
+        {
+            "type": "data",
+            "id": "123",
+            "payload": {
+                "data": {"test": ["1", "2"]}
+            }
+        }
+        """,
+        """
+        {
+            "type": "complete",
+            "id": "123"
+        }
+        """,
+    ]
+    eq_(list(endpoint('query {test}')), [{'data': {'test': ['1', '2']}}])
+
+
+@patch('sgqlc.endpoint.websocket.websocket')
+def test_operation_query(mock_websocket):
+    'Test if query with type sgqlc.operation.Operation() or raw bytes works'
+
+    schema = Schema()
+
+    # MyType and Query may be declared if doctests were processed by nose
+    if 'MyType' in schema:
+        schema -= schema.MyType
+
+    if 'Query' in schema:
+        schema -= schema.Query
+
+    class MyType(Type):
+        __schema__ = schema
+        i = int
+
+    class Query(Type):
+        __schema__ = schema
+        my_type = MyType
+
+    op = Operation(Query)
+    op.my_type.i()
+
+    mock_connection = Mock()
+    mock_websocket.create_connection.return_value = mock_connection
+    return_values = [
+        """
+        {
+            "type": "connection_ack",
+            "id": "123"
+        }
+        """,
+        """
+        {
+            "type": "data",
+            "id": "123",
+            "payload": {
+                "data": {"test": ["1", "2"]}
+            }
+        }
+        """,
+        """
+        {
+            "type": "complete",
+            "id": "123"
+        }
+        """,
+    ]
+    # query twice so double ret values twice
+    return_values.extend(return_values)
+    mock_connection.recv.side_effect = return_values
+    eq_(list(endpoint(op)), [{'data': {'test': ['1', '2']}}])
+    eq_(list(endpoint(bytes(op))), [{'data': {'test': ['1', '2']}}])
+    eq_(
+        bytes(
+            json.loads(
+                mock_connection.send.call_args_list[1][0][0]
+            )['payload']['query'],
+            encoding='utf-8'),
+        bytes(op)
+    )
+
+
+@patch('sgqlc.endpoint.websocket.websocket')
+def test_basic_subscription(mock_websocket):
+    'Test websocket endpoint against simple subscription query'
+    mock_connection = Mock()
+    mock_websocket.create_connection.return_value = mock_connection
+    mock_connection.recv.side_effect = [
+        """
+        {
+            "type": "connection_ack",
+            "id": "123"
+        }
+        """,
+        """
+        {
+            "type": "data",
+            "id": "123",
+            "payload": {
+                "data": {"test": "1"}
+            }
+        }
+        """,
+        """
+        {
+            "type": "data",
+            "id": "123",
+            "payload": {
+                "data": {"test": "2"}
+            }
+        }
+        """,
+        """
+        {
+            "type": "complete",
+            "id": "123"
+        }
+        """,
+    ]
+    eq_(
+        list(endpoint('subscription {test}')),
+        [{'data': {'test': '1'}}, {'data': {'test': '2'}}]
+    )
+
+
+@patch('sgqlc.endpoint.websocket.websocket')
+def test_unexpected_ack(mock_websocket):
+    'Test bad message type when waiting for ack'
+    mock_connection = Mock()
+    mock_websocket.create_connection.return_value = mock_connection
+    mock_connection.recv.side_effect = [
+        """
+        {
+            "type": "data",
+            "id": "123",
+            "payload": {
+                "data": {"test": "1"}
+            }
+        }
+        """
+    ]
+    try:
+        list(endpoint('query {test}'))
+        raise Exception('should have failed')
+    except ValueError as e:
+        eq_(e.args[0], 'Unexpected data when waiting for connection ack')
+
+
+@patch('sgqlc.endpoint.websocket.websocket')
+def test_unexpected_ack_id(mock_websocket):
+    'Test bad message id when waiting for ack'
+    mock_connection = Mock()
+    mock_websocket.create_connection.return_value = mock_connection
+    mock_connection.recv.side_effect = [
+        """
+        {
+            "type": "connection_ack",
+            "id": "321",
+            "payload": {
+                "data": {"test": "1"}
+            }
+        }
+        """
+    ]
+    try:
+        list(endpoint('query {test}'))
+        raise Exception('should have failed')
+    except ValueError as e:
+        eq_(e.args[0], 'Unexpected id 321 when waiting for connection ack')
+
+
+@patch('sgqlc.endpoint.websocket.websocket')
+def test_query_bad_message(mock_websocket):
+    'Test bad message type when waiting for query'
+    mock_connection = Mock()
+    mock_websocket.create_connection.return_value = mock_connection
+    mock_connection.recv.side_effect = [
+        """
+        {
+            "type": "connection_ack",
+            "id": "123"
+        }
+        """,
+        """
+        {
+            "type": "error",
+            "id": "123",
+            "payload": {
+                "data": {"test": ["1", "2"]}
+            }
+        }
+        """,
+    ]
+    try:
+        list(endpoint('query {test}'))
+        raise Exception('should have failed')
+    except ValueError as e:
+        eq_(e.args[0].startswith('Unexpected message'), True)
+        eq_(e.args[0].endswith('when waiting for query results'), True)
+
+
+@patch('sgqlc.endpoint.websocket.websocket')
+def test_query_bad_message_id(mock_websocket):
+    'Test bad message id when waiting for query'
+    mock_connection = Mock()
+    mock_websocket.create_connection.return_value = mock_connection
+    mock_connection.recv.side_effect = [
+        """
+        {
+            "type": "connection_ack",
+            "id": "123"
+        }
+        """,
+        """
+        {
+            "type": "data",
+            "id": "321",
+            "payload": {
+                "data": {"test": ["1", "2"]}
+            }
+        }
+        """,
+    ]
+    try:
+        list(endpoint('query {test}'))
+        raise Exception('should have failed')
+    except ValueError as e:
+        eq_(e.args[0], 'Unexpected id 321 when waiting for query results')


### PR DESCRIPTION
Implement the apollo graphql-ws protocol as a subclass
of BaseEndpoint.  Allows for both 'normal' queries as
well as subscriptions to be executed over a websocket
and collects results to a list.  The list can then be
interpreted to Operation based objects by:
  [(op + result) for result in endpoint(op)]

Fixes #26.