### PR TITLE
Support canceling queries and reusing websockets

### DIFF
--- a/sgqlc/endpoint/websocket.py
+++ b/sgqlc/endpoint/websocket.py
@@ -1,36 +1,122 @@
+from typing import Dict, Any, Union, SupportsBytes, Iterable
+from websocket import WebSocket
+
 from sgqlc.endpoint.base import BaseEndpoint
 import websocket
 import uuid
 import json
 
 
+class CancelableResultGenerator:
+    '''
+    Generator of websocket subscription notification events that supports
+    sending a message to the server to cancel the subscription.
+    '''
+    def __init__(self, ws: WebSocket, query_id: str, should_close: bool):
+        '''
+        :param ws: websocket to get results from
+        :type ws: WebSocket
+
+        :param query_id: query_id to track
+        :type query_id: str
+
+        :param should_close: whether to close the socket after
+          completing iteration on the results
+        :type should_close: bool
+        '''
+        self.ws = ws
+        self.query_id = query_id
+        self.should_close = should_close
+
+    def __next__(self) -> dict:
+        response = json.loads(self.ws.recv())
+        if response['id'] != self.query_id:
+            raise ValueError(
+                f'Unexpected id {response["id"]} '
+                f'when waiting for query results'
+            )
+        if response['type'] == 'data':
+            return response['payload']
+        elif response['type'] == 'complete':
+            if self.should_close:
+                self.ws.close()
+            raise StopIteration()
+        else:
+            raise ValueError(f'Unexpected message {response} '
+                             f'when waiting for query results')
+
+    def __iter__(self):
+        return self
+
+    def cancel(self):
+        self.ws.send(json.dumps({'type': 'stop', 'id': self.query_id}))
+
+
 class WebSocketEndpoint(BaseEndpoint):
     '''
-    A synchronous websocket endpoint for graphql queries or subscriptions
+    A websocket endpoint for graphql queries or subscriptions.
+    Will return a generator of response objects when called.
     '''
-    def __init__(self, url, **ws_options):
+    def __init__(self, url: str = None, ws: WebSocket = None, **ws_options):
         '''
         :param url: ws:// or wss:// url to connect to
         :type url: str
+
+        :param ws: existing websocket connection to use instead of
+          creating a new one.  if passing an existing connection,
+          the calling code is responsible for both closing it and
+          handling the ``connection_init``/``connection ack``
+          handshake.
+        :type ws: WebSocket
 
         :param ws_options: options to pass to websocket.create_connection
         :type ws_options: dict
         '''
         self.url = url
+        self.ws = ws
         self.ws_options = ws_options
 
-    def __str__(self):
+    def __str__(self) -> str:
         return '%s(url=%s, ws_options=%s)' % (
             self.__class__.__name__, self.url, self.ws_options)
 
-    def __call__(self, query, variables=None, operation_name=None):
+    def _create_connection(self) -> WebSocket:
+        '''
+        Create a new websocket connection and handle the
+        ``connection_init``/``connection_ack`` handshake.
+        :return: websocket connection
+        :rtype: WebSocket
+        '''
+        ws = websocket.create_connection(self.url,
+                                         subprotocols=['graphql-ws'],
+                                         **self.ws_options)
+        init_id = self.generate_id()
+        ws.send(json.dumps({'type': 'connection_init', 'id': init_id}))
+        response = json.loads(ws.recv())
+        if response['type'] != 'connection_ack':
+            raise ValueError(
+                f'Unexpected {response["type"]} '
+                f'when waiting for connection ack'
+            )
+        if response['id'] != init_id:
+            raise ValueError(
+                f'Unexpected id {response["id"]} '
+                f'when waiting for connection ack'
+            )
+        return ws
+
+    def __call__(self,
+                 query: Union[str, Union[bytes, SupportsBytes]],
+                 variables: Dict[str, Any] = None,
+                 operation_name: str = None) -> Iterable:
         '''
         Makes a single query over the websocket
 
-        :param query: the GraphQL query or mutation to execute. Note
-          that this is converted using ``bytes()``, thus one may pass
-          an object implementing ``__bytes__()`` method to return the
-          query, eventually in more compact form (no indentation, etc).
+        :param query: the GraphQL query, subscription, or mutation to
+          execute. Note that this is converted using ``bytes()``, thus
+          one may pass an object implementing ``__bytes__()`` method to
+          return the query, eventually in more compact form (no
+          indentation, etc).
         :type query: :class:`str` or :class:`bytes`.
 
         :param variables: variables (dict) to use with
@@ -53,52 +139,24 @@ class WebSocketEndpoint(BaseEndpoint):
 
         :rtype: generator
         '''
+
         if isinstance(query, bytes):
             query = query.decode('utf-8')
         elif not isinstance(query, str):
             # allows sgqlc.operation.Operation to be passed
             # and generate compact representation of the queries
             query = bytes(query).decode('utf-8')
-        ws = websocket.create_connection(self.url,
-                                         subprotocols=['graphql-ws'],
-                                         **self.ws_options)
-        try:
-            init_id = self.generate_id()
-            ws.send(json.dumps({'type': 'connection_init', 'id': init_id}))
-            response = json.loads(ws.recv())
-            if response['type'] != 'connection_ack':
-                raise ValueError(
-                    f'Unexpected {response["type"]} '
-                    f'when waiting for connection ack'
-                )
-            if response['id'] != init_id:
-                raise ValueError(
-                    f'Unexpected id {response["id"]} '
-                    f'when waiting for connection ack'
-                )
+        ws = self.ws
+        if not ws:
+            ws = self._create_connection()
 
-            query_id = self.generate_id()
-            ws.send(json.dumps({'type': 'start',
-                                'id': query_id,
-                                'payload': {'query': query,
-                                            'variables': variables,
-                                            'operationName': operation_name}}))
-            response = json.loads(ws.recv())
-            while response['type'] != 'complete':
-                if response['id'] != query_id:
-                    raise ValueError(
-                        f'Unexpected id {response["id"]} '
-                        f'when waiting for query results'
-                    )
-                if response['type'] == 'data':
-                    yield response['payload']
-                else:
-                    raise ValueError(f'Unexpected message {response} '
-                                     f'when waiting for query results')
-                response = json.loads(ws.recv())
-
-        finally:
-            ws.close()
+        query_id = self.generate_id()
+        ws.send(json.dumps({'type': 'start',
+                            'id': query_id,
+                            'payload': {'query': query,
+                                        'variables': variables,
+                                        'operationName': operation_name}}))
+        return CancelableResultGenerator(ws, query_id, not self.ws)
 
     @staticmethod
     def generate_id() -> str:

--- a/tests/test-endpoint-websocket.py
+++ b/tests/test-endpoint-websocket.py
@@ -1,3 +1,4 @@
+import itertools
 import json
 import re
 from unittest.mock import patch, Mock
@@ -63,6 +64,46 @@ def test_basic_query(mock_websocket):
         """,
     ]
     eq_(list(endpoint('query {test}')), [{'data': {'test': ['1', '2']}}])
+    mock_connection.close.assert_called_once()
+
+
+def test_basic_query_existing_websocket():
+    'Test websocket endpoint against simple query using existing connection'
+    mock_connection = Mock()
+    mock_connection.recv.side_effect = [
+        """
+        {
+            "type": "data",
+            "id": "123",
+            "payload": {
+                "data": {"test": ["1", "2"]}
+            }
+        }
+        """,
+        """
+        {
+            "type": "complete",
+            "id": "123"
+        }
+        """,
+    ]
+    existing_connection_endpoint = WebSocketEndpoint(ws=mock_connection)
+    existing_connection_endpoint.generate_id = lambda: '123'
+    eq_(
+        list(existing_connection_endpoint('query {test}')),
+        [{'data': {'test': ['1', '2']}}]
+    )
+    mock_connection.close.assert_not_called()
+    eq_(len(mock_connection.send.call_args_list), 1)
+    sent_message = mock_connection.send.call_args_list[0][0][0]
+    eq_(
+        '"type": "start"' in sent_message,
+        True
+    )
+    eq_(
+        '"query": "query {test}"' in sent_message,
+        True
+    )
 
 
 @patch('sgqlc.endpoint.websocket.websocket')
@@ -275,3 +316,47 @@ def test_query_bad_message_id(mock_websocket):
         raise Exception('should have failed')
     except ValueError as e:
         eq_(e.args[0], 'Unexpected id 321 when waiting for query results')
+
+
+@patch('sgqlc.endpoint.websocket.websocket')
+def test_stop_generator(mock_websocket):
+    'Test stopping the generator while iterating through'
+    mock_connection = Mock()
+    mock_websocket.create_connection.return_value = mock_connection
+    mock_connection.recv.side_effect = [
+        """
+        {
+            "type": "connection_ack",
+            "id": "123"
+        }
+        """,
+        """
+        {
+            "type": "data",
+            "id": "123",
+            "payload": {
+                "data": {"test": "1"}
+            }
+        }
+        """,
+        """
+        {
+            "type": "data",
+            "id": "123",
+            "payload": {
+                "data": {"test": "2"}
+            }
+        }
+        """,
+        """
+        {
+            "type": "complete",
+            "id": "123"
+        }
+        """,
+    ]
+    generator = endpoint('subscription {test}')
+    first = [x for x in itertools.islice(generator, 1)][0]
+    generator.cancel()
+    eq_(first, {'data': {'test': '1'}})
+    eq_(mock_connection.send.call_args[0][0], '{"type": "stop", "id": "123"}')


### PR DESCRIPTION
Move the generator implementation into a dedicated class
to allow for canceling of running queries.  Also support
passing an already connected websocket to the endpoint
to allow multiple queries to happen on the same connection.

Note: in order to support multiple concurrent connections,
this probably needs to move to using websocket-client's
asynchronous WebSocketApp instead of synchronously
calling websocket.create_connection().recv(), and ensuring
the notification messages get routed to the correct
generator.

-------------------
This PR is the first step following up on discussion in #55 
see `Note` above / in the commit message for at least one
shortcoming.  Don't currently have the time to handle that
use case, but maybe someone else wants to pick up from
here.