### PR TITLE
Adding support for hasura.io (+apollo?) subscriptions

### DIFF
--- a/tests/test-endpoint-websocket.py
+++ b/tests/test-endpoint-websocket.py
@@ -66,6 +66,57 @@ def test_basic_query(mock_websocket):
 
 
 @patch('sgqlc.endpoint.websocket.websocket')
+def test_basic_query_apollo(mock_websocket):
+    '''Test websocket endpoint against simple apollo query with keepalive
+    and no id in connection_ack'''
+    mock_connection = Mock()
+    mock_websocket.create_connection.return_value = mock_connection
+    mock_connection.recv.side_effect = [
+        """
+        {
+            "type": "connection_ack"
+        }
+        """,
+        """
+        {
+            "type": "ka"
+        }
+        """,
+        """
+        {
+            "type": "ka"
+        }
+        """,
+        """
+        {
+            "type": "data",
+            "id": "123",
+            "payload": {
+                "data": {"test": ["1", "2"]}
+            }
+        }
+        """,
+        """
+        {
+            "type": "ka"
+        }
+        """,
+        """
+        {
+            "type": "ka"
+        }
+        """,
+        """
+        {
+            "type": "complete",
+            "id": "123"
+        }
+        """,
+    ]
+    eq_(list(endpoint('query {test}')), [{'data': {'test': ['1', '2']}}])
+
+
+@patch('sgqlc.endpoint.websocket.websocket')
 def test_operation_query(mock_websocket):
     'Test if query with type sgqlc.operation.Operation() or raw bytes works'
 


### PR DESCRIPTION
I was testing with [hasura.io](https://hasura.io) sample and subscriptions did not work. It seems to based upon apollo that will send keep alives periodically (`{"type": "ka"}`) (see [GQL_CONNECTION_KEEP_ALIVE](https://github.com/apollographql/subscriptions-transport-ws/blob/faa219cff7b6f9873cae59b490da46684d7bea19/src/message-types.ts#L7). 

Additionally, it does not always return the `ID` in the `connection_ack`

I have update websocket to ignore `ka` messages and to handle the case where id is not sent in the connection_ack

UPDATED: Just noticed that this partially  repeats #57