### PR TITLE
Fixed ValueError with None in Union field

### DIFF
--- a/sgqlc/types/__init__.py
+++ b/sgqlc/types/__init__.py
@@ -1454,6 +1454,8 @@ class Union(BaseTypeWithTypename, metaclass=UnionMeta):
     >>> data = {'__typename': 'TypeUnknown', 'v': 123}
     >>> TypeU(data) # auto-generates empty types
     TypeUnknown()
+    >>> data = None
+    >>> TypeU(data)
 
     '''
 
@@ -1461,6 +1463,9 @@ class Union(BaseTypeWithTypename, metaclass=UnionMeta):
     __types__ = ()
 
     def __new__(cls, json_data, selection_list=None):
+        if json_data is None:
+            return
+
         type_name = json_data.get('__typename')
         if not type_name:
             t = UnknownType


### PR DESCRIPTION
Fix ValueError:
.... selection 'selection_name': None ('NoneType' object has no attribute 'get'))

It is happens when Union type selection get None value