### PR TITLE
Add endpoint.requests to support graphql http operations with auth

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,7 @@ name = "pypi"
 sgqlc = {editable = true,path = "."}
 graphql-core = "*"
 websocket-client = "==0.56.0"
+requests = "*"
 
 [dev-packages]
 "flake8" = "*"
@@ -25,6 +26,7 @@ websocket-client = "==0.56.0"
 pygments = "*"
 nose = "*"
 sphinx = "*"
+requests = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "759b23349152de45707c81f682dee56cc5bdf5df3d8f10321ed2a21634db4879"
+            "sha256": "73919352bf01c42ac6646e02fda773debe2b440f2925e37a6bbd44dd775f8bb3"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,6 +16,20 @@
         ]
     },
     "default": {
+        "certifi": {
+            "hashes": [
+                "sha256:e4f3620cfea4f83eedc95b24abd9cd56f3c4b146dd0177e83a21b4eb49e21e50",
+                "sha256:fd7c7c74727ddcf00e9acd26bba8da604ffec95bf1c2144e67aff7a8b50e6cef"
+            ],
+            "version": "==2019.9.11"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
+        },
         "graphql-core": {
             "hashes": [
                 "sha256:1488f2a5c2272dc9ba66e3042a6d1c30cea0db4c80bd1e911c6791ad6187d91b",
@@ -24,12 +38,27 @@
             "index": "pypi",
             "version": "==2.2.1"
         },
+        "idna": {
+            "hashes": [
+                "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
+                "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
+            ],
+            "version": "==2.8"
+        },
         "promise": {
             "hashes": [
                 "sha256:2ebbfc10b7abf6354403ed785fe4f04b9dfd421eb1a474ac8d187022228332af",
                 "sha256:348f5f6c3edd4fd47c9cd65aed03ac1b31136d375aa63871a57d3e444c85655c"
             ],
             "version": "==2.2.1"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4",
+                "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"
+            ],
+            "index": "pypi",
+            "version": "==2.22.0"
         },
         "rx": {
             "hashes": [
@@ -44,10 +73,17 @@
         },
         "six": {
             "hashes": [
-                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
-                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+                "sha256:1f1b7d42e254082a9db6279deae68afb421ceba6158efa6131de7b3003ee93fd",
+                "sha256:30f610279e8b2578cab6db20741130331735c781b56053c59c4076da27f06b66"
             ],
-            "version": "==1.12.0"
+            "version": "==1.13.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:3de946ffbed6e6746608990594d08faac602528ac7015ac28d33cee6a45b7398",
+                "sha256:9a107b99a5393caf59c7aa3c1249c16e6879447533d0887f4336dde834c7be86"
+            ],
+            "version": "==1.25.6"
         },
         "websocket-client": {
             "hashes": [
@@ -66,13 +102,6 @@
             ],
             "version": "==0.7.12"
         },
-        "attrs": {
-            "hashes": [
-                "sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79",
-                "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
-            ],
-            "version": "==19.1.0"
-        },
         "babel": {
             "hashes": [
                 "sha256:af92e6106cb7c55286b25b38ad7695f8b4efb36a90ba483d7f7a6628c46158ab",
@@ -82,10 +111,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:046832c04d4e752f37383b628bc601a7ea7211496b4638f6514d0e5b9acc4939",
-                "sha256:945e3ba63a0b9f577b1395204e13c3a231f9bc0223888be653286534e5873695"
+                "sha256:e4f3620cfea4f83eedc95b24abd9cd56f3c4b146dd0177e83a21b4eb49e21e50",
+                "sha256:fd7c7c74727ddcf00e9acd26bba8da604ffec95bf1c2144e67aff7a8b50e6cef"
             ],
-            "version": "==2019.6.16"
+            "version": "==2019.9.11"
         },
         "chardet": {
             "hashes": [
@@ -118,11 +147,11 @@
         },
         "flake8": {
             "hashes": [
-                "sha256:19241c1cbc971b9962473e4438a2ca19749a7dd002dd1a946eaba171b4114548",
-                "sha256:8e9dfa3cecb2400b3738a42c54c3043e821682b9c840b0448c0503f781130696"
+                "sha256:45681a117ecc81e870cbf1262835ae4af5e7a8b08e40b944a8a6e6b895914cfb",
+                "sha256:49356e766643ad15072a789a20915d3c91dc89fd313ccd71802303fd67e4deca"
             ],
             "index": "pypi",
-            "version": "==3.7.8"
+            "version": "==3.7.9"
         },
         "flake8-builtins": {
             "hashes": [
@@ -141,11 +170,11 @@
         },
         "flake8-comprehensions": {
             "hashes": [
-                "sha256:7b174ded3d7e73edf587e942458b6c1a7c3456d512d9c435deae367236b9562c",
-                "sha256:e36fc12bd3833e0b34fe0639b7a817d32c86238987f532078c57eafdc7a8a219"
+                "sha256:d1337979289e2877693b49a862c3e193a443833e2843e0e2450d54abd93aea9a",
+                "sha256:d3a8339e262205a15a4a84f6363eabb63e2dbd8292c4655366aaa0452eb28496"
             ],
             "index": "pypi",
-            "version": "==2.2.0"
+            "version": "==3.0.1"
         },
         "flake8-deprecated": {
             "hashes": [
@@ -165,10 +194,10 @@
         },
         "flake8-print": {
             "hashes": [
-                "sha256:5010e6c138b63b62400da4b06afa33becc5e08bd1fcce9af3752445cf3342f54"
+                "sha256:324f9e59a522518daa2461bacd7f82da3c34eb26a4314c2a54bd493f8b394a68"
             ],
             "index": "pypi",
-            "version": "==3.1.0"
+            "version": "==3.1.4"
         },
         "flake8-regex": {
             "hashes": [
@@ -200,11 +229,11 @@
         },
         "flake8-tidy-imports": {
             "hashes": [
-                "sha256:1c476aabc6e8db26dc75278464a3a392dba0ea80562777c5f13fd5cdf2646154",
-                "sha256:b3f5b96affd0f57cacb6621ed28286ce67edaca807757b51227043ebf7b136a1"
+                "sha256:8460933e89449e2e9d1d38ef1c099ad713d67cd1d13f172b8d025030a9887a6f",
+                "sha256:a1f6a962ce4e733858187c1c047f98246e400af2e6bed90e780d888e439938da"
             ],
             "index": "pypi",
-            "version": "==2.0.0"
+            "version": "==3.0.0"
         },
         "idna": {
             "hashes": [
@@ -222,18 +251,18 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:9ff1b1c5a354142de080b8a4e9803e5d0d59283c93aed808617c787d16768375",
-                "sha256:b7143592e374e50584564794fcb8aaf00a23025f9db866627f89a21491847a8d"
+                "sha256:aa18d7378b00b40847790e7c27e11673d7fed219354109d0e7b9e5b25dc3ad26",
+                "sha256:d5f18a79777f3aa179c145737780282e27b508fc8fd688cb17c7a813e8bd39af"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==0.20"
+            "version": "==0.23"
         },
         "jinja2": {
             "hashes": [
-                "sha256:065c4f02ebe7f7cf559e49ee5a95fb800a9e4528727aec6f24402a5374c65013",
-                "sha256:14dd6caf1527abb21f08f86c784eac40853ba93edb79552aa1e4b8aef1b61c7b"
+                "sha256:74320bb91f31270f9551d46522e33af46a80c3d619f4a4bf42b3164d30b5911f",
+                "sha256:9fe95f19286cfefaa917656583d020be14e7859c6b0252588391e47db34527de"
             ],
-            "version": "==2.10.1"
+            "version": "==2.10.3"
         },
         "markupsafe": {
             "hashes": [
@@ -293,10 +322,10 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:a7ac867b97fdc07ee80a8058fe4435ccd274ecc3b0ed61d852d7d53055528cf9",
-                "sha256:c491ca87294da7cc01902edbe30a5bc6c4c28172b5138ab4e4aa1b9d7bfaeafe"
+                "sha256:28b924174df7a2fa32c1953825ff29c61e2f5e082343165438812f00d3a7fc47",
+                "sha256:d9551545c6d761f3def1677baf08ab2a3ca17c56879e70fecba2fc4dde4ed108"
             ],
-            "version": "==19.1"
+            "version": "==19.2"
         },
         "pep8": {
             "hashes": [
@@ -308,10 +337,10 @@
         },
         "pluggy": {
             "hashes": [
-                "sha256:0825a152ac059776623854c1543d65a4ad408eb3d33ee114dff91e57ec6ae6fc",
-                "sha256:b9817417e95936bf75d85d3f8767f7df6cdde751fc40aed3bb3074cbcb77757c"
+                "sha256:0db4b7601aae1d35b4a033282da476845aa19185c1e6964b25cf324b5e4ec3e6",
+                "sha256:fa5fa1622fa6dd5c030e9cad086fa19ef6a0cf6d7a2d12318e10cb49d6d68f34"
             ],
-            "version": "==0.12.0"
+            "version": "==0.13.0"
         },
         "py": {
             "hashes": [
@@ -344,23 +373,24 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:6f98a7b9397e206d78cc01df10131398f1c8b8510a2f4d97d9abd82e1aacdd80",
-                "sha256:d9338df12903bbf5d65a0e4e87c2161968b10d2e489652bb47001d82a9b028b4"
+                "sha256:4acadc9a2b96c19fe00932a38ca63e601180c39a189a696abce1eaab641447e1",
+                "sha256:61b5ed888beab19ddccab3478910e2076a6b5a0295dffc43021890e136edf764"
             ],
-            "version": "==2.4.2"
+            "version": "==2.4.4"
         },
         "pytz": {
             "hashes": [
-                "sha256:26c0b32e437e54a18161324a2fca3c4b9846b74a8dccddd843113109e1116b32",
-                "sha256:c894d57500a4cd2d5c71114aaab77dbab5eabd9022308ce5ac9bb93a60a6f0c7"
+                "sha256:1c557d7d0e871de1f5ccd5833f60fb2550652da6be2693c1e02300743d21500d",
+                "sha256:b02c06db6cf09c12dd25137e563b31700d3b80fcc4ad23abb7a315f2789819be"
             ],
-            "version": "==2019.2"
+            "version": "==2019.3"
         },
         "requests": {
             "hashes": [
                 "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4",
                 "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"
             ],
+            "index": "pypi",
             "version": "==2.22.0"
         },
         "restructuredtext-lint": {
@@ -371,24 +401,25 @@
         },
         "six": {
             "hashes": [
-                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
-                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+                "sha256:1f1b7d42e254082a9db6279deae68afb421ceba6158efa6131de7b3003ee93fd",
+                "sha256:30f610279e8b2578cab6db20741130331735c781b56053c59c4076da27f06b66"
             ],
-            "version": "==1.12.0"
+            "version": "==1.13.0"
         },
         "snowballstemmer": {
             "hashes": [
-                "sha256:713e53b79cbcf97bc5245a06080a33d54a77e7cce2f789c835a143bcdb5c033e"
+                "sha256:209f257d7533fdb3cb73bdbd24f436239ca3b2fa67d56f6ff88e86be08cc5ef0",
+                "sha256:df3bac3df4c2c01363f3dd2cfa78cce2840a79b9f1c2d2de9ce8d31683992f52"
             ],
-            "version": "==1.9.1"
+            "version": "==2.0.0"
         },
         "sphinx": {
             "hashes": [
-                "sha256:0d586b0f8c2fc3cc6559c5e8fd6124628110514fda0e5d7c82e682d749d2e845",
-                "sha256:839a3ed6f6b092bb60f492024489cc9e6991360fb9f52ed6361acd510d261069"
+                "sha256:31088dfb95359384b1005619827eaee3056243798c62724fd3fa4b84ee4d71bd",
+                "sha256:52286a0b9d7caa31efee301ec4300dbdab23c3b05da1c9024b4e84896fb73d79"
             ],
             "index": "pypi",
-            "version": "==2.2.0"
+            "version": "==2.2.1"
         },
         "sphinxcontrib-applehelp": {
             "hashes": [
@@ -448,17 +479,17 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:b246607a25ac80bedac05c6f282e3cdaf3afb65420fd024ac94435cabe6e18d1",
-                "sha256:dbe59173209418ae49d485b87d1681aefa36252ee85884c31346debd19463232"
+                "sha256:3de946ffbed6e6746608990594d08faac602528ac7015ac28d33cee6a45b7398",
+                "sha256:9a107b99a5393caf59c7aa3c1249c16e6879447533d0887f4336dde834c7be86"
             ],
-            "version": "==1.25.3"
+            "version": "==1.25.6"
         },
         "virtualenv": {
             "hashes": [
-                "sha256:680af46846662bb38c5504b78bad9ed9e4f3ba2d54f54ba42494fdf94337fe30",
-                "sha256:f78d81b62d3147396ac33fc9d77579ddc42cc2a98dd9ea38886f616b33bc7fb2"
+                "sha256:11cb4608930d5fd3afb545ecf8db83fa50e1f96fc4fca80c94b07d2c83146589",
+                "sha256:d257bb3773e48cac60e475a19b608996c73f4d333b3ba2e4e57d5ac6134e0136"
             ],
-            "version": "==16.7.5"
+            "version": "==16.7.7"
         },
         "zipp": {
             "hashes": [

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -169,6 +169,9 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/3/': None}
+intersphinx_mapping = {
+    'https://docs.python.org/3/': None,
+    'https://3.python-requests.org/': None
+}
 
 # -- Extension interface -------------------------------------------------------

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -23,6 +23,7 @@ Table of Contents
    sgqlc.endpoint
    sgqlc.endpoint.base
    sgqlc.endpoint.http
+   sgqlc.endpoint.requests
 
 
 Indices and tables

--- a/doc/source/sgqlc.endpoint.requests.rst
+++ b/doc/source/sgqlc.endpoint.requests.rst
@@ -1,0 +1,8 @@
+`sgqlc.endpoint.requests` module
+================================
+
+.. automodule:: sgqlc.endpoint.requests
+    :members:
+    :special-members:
+    :show-inheritance:
+    :private-members:

--- a/doc/source/sgqlc.endpoint.rst
+++ b/doc/source/sgqlc.endpoint.rst
@@ -11,3 +11,4 @@ Sub Modules
 
 * :doc:`sgqlc.endpoint.base`
 * :doc:`sgqlc.endpoint.http`
+* :doc:`sgqlc.endpoint.requests`

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ tests= sgqlc/__init__.py,
    sgqlc/operation/__init__.py,
    tests/test-endpoint-http.py,
    tests/test-endpoint-websocket.py,
+   tests/test-endpoint-requests.py,
    tests/test-introspection.py
 
 [build_sphinx]

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
     extras_require={
         'sphinx': ['sphinx'],
         'websocket': ['websocket-client'],
+        'requests': ['requests']
     },
     zip_safe=True,
     keywords='graphql client http endpoint',

--- a/sgqlc/endpoint/__init__.py
+++ b/sgqlc/endpoint/__init__.py
@@ -12,6 +12,10 @@ This package provide the following modules:
    :class:`sgqlc.endpoint.http.HTTPEndpoint` using
    :func:`urllib.request.urlopen()`.
 
+ - :mod:`sgqlc.endpoint.requests`: concrete
+   :class:`sgqlc.endpoint.requests.RequestsEndpoint` using
+   :mod:`requests` .
+
 :license: ISC
 '''
 

--- a/sgqlc/endpoint/base.py
+++ b/sgqlc/endpoint/base.py
@@ -12,6 +12,36 @@ __docformat__ = 'reStructuredText en'
 __all__ = ('BaseEndpoint',)
 
 import logging
+import urllib.parse
+
+
+def add_query_to_url(url, extra_query):
+    '''Adds an extra query to URL, returning the new URL.
+
+    Extra query may be a dict or a list as returned by
+    :func:`urllib.parse.parse_qsl()` and :func:`urllib.parse.parse_qs()`.
+
+    '''
+    split = urllib.parse.urlsplit(url)
+    merged_query = urllib.parse.parse_qsl(split.query)
+    if isinstance(extra_query, dict):
+        for k, v in extra_query.items():
+            if not isinstance(v, (tuple, list)):
+                merged_query.append((k, v))
+            else:
+                for cv in v:
+                    merged_query.append((k, cv))
+    else:
+        merged_query.extend(extra_query)
+
+    merged_split = urllib.parse.SplitResult(
+        split.scheme,
+        split.netloc,
+        split.path,
+        urllib.parse.urlencode(merged_query),
+        split.fragment,
+    )
+    return merged_split.geturl()
 
 
 class BaseEndpoint:

--- a/sgqlc/endpoint/requests.py
+++ b/sgqlc/endpoint/requests.py
@@ -92,7 +92,7 @@ class RequestsEndpoint(BaseEndpoint):
         return ('%s(url=%s, base_headers=%r, timeout=%r, '
                 'method=%s, auth=%s)') % (
             self.__class__.__name__, self.url, self.base_headers, self.timeout,
-            self.method, 
+            self.method,
             self.auth.__class__ if self.auth is not None else None)
 
     def __call__(self, query, variables=None,  # noqa: C901

--- a/tests/test-endpoint-requests.py
+++ b/tests/test-endpoint-requests.py
@@ -217,22 +217,24 @@ def test_basic(mock_requests_send):
         + 'url={}, '.format(test_url)
         + 'base_headers={}, timeout=None, method=POST, auth=None)')
 
+
 @patch('requests.sessions.Session.send')
 def test_basic_auth(mock_requests_send):
     '[Requests] - Test if basic usage with only auth works'
 
     configure_mock_requests_send(mock_requests_send, graphql_response_ok)
 
-    endpoint = RequestsEndpoint(test_url, 
-               auth=requests.auth.HTTPBasicAuth("user", "password"))
+    endpoint = RequestsEndpoint(test_url,
+                                auth=requests.auth.HTTPBasicAuth("user",
+                                                                 "password"))
     data = endpoint(graphql_query)
     eq_(data, json.loads(graphql_response_ok))
     check_mock_requests_send(mock_requests_send)
     eq_(str(endpoint),
         'RequestsEndpoint('
         + 'url={}, '.format(test_url)
-        + 'base_headers={}, timeout=None, method=POST, auth=<class \'requests.auth.HTTPBasicAuth\'>)')
-
+        + 'base_headers={}, timeout=None, method=POST, '
+        + 'auth=<class \'requests.auth.HTTPBasicAuth\'>)')
 
 
 @patch('requests.sessions.Session.send')
@@ -361,7 +363,7 @@ def test_operation_name(mock_requests_send):
 def test_json_error(mock_requests_send):
     '[Requests] - Test if broken server responses (invalid JSON) is handled'
 
-    configure_mock_requests_send(mock_requests_send, 
+    configure_mock_requests_send(mock_requests_send,
                                  graphql_response_json_error)
 
     endpoint = RequestsEndpoint(test_url)

--- a/tests/test-endpoint-requests.py
+++ b/tests/test-endpoint-requests.py
@@ -1,0 +1,645 @@
+import io
+import json
+import requests
+import urllib
+
+from nose.tools import eq_
+from unittest.mock import patch
+from sgqlc.endpoint.requests import RequestsEndpoint, add_query_to_url
+from sgqlc.types import Schema, Type
+from sgqlc.operation import Operation
+
+
+class MockResponse:
+    def __init__(self, json_data, status_code):
+        self.json_data = json_data
+        self.status_code = status_code
+        self.text = json_data
+
+    def __enter__(self):
+        return self
+
+    def raise_for_status(self):
+        pass
+
+    def __exit__(self, exception_type, exception_value, traceback):
+        pass
+
+    def json(self):
+        return json.loads(self.json_data)
+
+
+test_url = 'http://some-server.com/graphql'
+
+extra_accept_header = ', '.join([
+    'application/json; charset=utf-8',
+    'application/vnd.xyz.feature-flag+json',
+])
+
+graphql_query = '''
+query GitHubRepoIssues($repoOwner: String!, $repoName: String!) {
+  repository(owner: $repoOwner, name: $repoName) {
+    issues(first: 100) {
+      nodes {
+        number
+        title
+      }
+    }
+  }
+}
+'''
+
+graphql_response_ok = '''
+{
+  "data": {
+    "repository": {
+      "issues": {
+        "nodes": [
+          {
+            "number": 1,
+            "title": "unit tests: sgqlc.types"
+          }
+        ]
+      }
+    }
+  }
+}'''
+
+graphql_response_error = '''
+{
+  "errors": [{
+    "message": "Server Reported Error",
+    "locations": [{"line": 1, "column": 1}]
+  }, {
+    "message": "Other Message",
+    "path": ["repository", "issues"]
+  }]
+}
+'''
+
+graphql_response_json_error = '''
+{
+  "data": {
+'''
+
+# -- Test Helpers --
+
+
+def get_json_exception(s):
+    try:
+        json.loads(s)
+        return None
+    except json.JSONDecodeError as e:
+        return e
+
+
+def configure_mock_requests_send(mock_requests_send, payload):
+    if isinstance(payload, Exception):
+        mock_requests_send.side_effect = payload
+    else:
+        mock_requests_send.return_value = MockResponse(payload, 200)
+
+
+def check_request_url(req, expected):
+    split = urllib.parse.urlsplit(req.url)
+    received = urllib.parse.SplitResult(
+        split.scheme,
+        split.netloc,
+        split.path,
+        None,
+        split.fragment,
+    ).geturl()
+    eq_(received, expected)
+
+
+def check_request_headers_(req, headers, name):
+    if not headers:
+        return
+    if isinstance(headers, dict):
+        headers = headers.items()
+    for k, v in headers:
+        g = req.headers.get(k)
+        eq_(g, v, 'Failed {} header {}: {!r} != {!r}'.format(name, k, v, g))
+
+
+def check_request_headers(req, base_headers, extra_headers):
+    if extra_headers and 'Accept' in extra_headers:
+        accept_header = extra_accept_header
+    else:
+        accept_header = 'application/json; charset=utf-8'
+    eq_(req.headers.get('Accept'), accept_header)
+    if req.method == 'POST':
+        eq_(req.headers.get('Content-type'), 'application/json; charset=utf-8')
+    check_request_headers_(req, base_headers, 'base')
+    check_request_headers_(req, extra_headers, 'extra')
+
+
+def get_request_url_query(req):
+    split = urllib.parse.urlsplit(req.url)
+    query = urllib.parse.parse_qsl(split.query)
+    if isinstance(query, list):
+        query = dict(query)
+    return query
+
+
+def check_request_variables(req, variables):
+    if req.method == 'POST':
+        post_data = json.loads(req.body)
+        received = post_data.get('variables')
+    else:
+        query = get_request_url_query(req)
+        received = json.loads(query.get('variables', 'null'))
+
+    eq_(received, variables)
+
+
+def check_request_operation_name(req, operation_name):
+    if req.method == 'POST':
+        post_data = json.loads(req.body)
+        received = post_data.get('operationName')
+    else:
+        query = get_request_url_query(req)
+        received = query.get('operationName')
+
+    eq_(received, operation_name)
+
+
+def check_request_query(req, query):
+    if req.method == 'POST':
+        post_data = json.loads(req.body)
+        received = post_data.get('query')
+    else:
+        query_data = get_request_url_query(req)
+        received = query_data.get('query')
+
+    if isinstance(query, bytes):
+        query = query.decode('utf-8')
+
+    eq_(received, query)
+
+
+def check_mock_requests_send(mock_requests_send,
+                             method='POST',
+                             timeout=None,
+                             base_headers=None,
+                             extra_headers=None,
+                             variables=None,
+                             operation_name=None,
+                             query=None,  # defaults to `graphql_query`
+                             ):
+    assert mock_requests_send.called
+    args = mock_requests_send.call_args
+    req = args[0][0]
+    eq_(req.method, method)
+    check_request_url(req, test_url)
+    check_request_headers(req, base_headers, extra_headers)
+    check_request_variables(req, variables)
+    check_request_operation_name(req, operation_name)
+    check_request_query(req, query or graphql_query)
+    eq_(args[1]['timeout'], timeout)
+
+
+# -- Actual Tests --
+
+
+@patch('requests.sessions.Session.send')
+def test_basic(mock_requests_send):
+    '[Requests] - Test if basic usage with only essential parameters works'
+
+    configure_mock_requests_send(mock_requests_send, graphql_response_ok)
+
+    endpoint = RequestsEndpoint(test_url)
+    data = endpoint(graphql_query)
+    eq_(data, json.loads(graphql_response_ok))
+    check_mock_requests_send(mock_requests_send)
+    eq_(str(endpoint),
+        'RequestsEndpoint('
+        + 'url={}, '.format(test_url)
+        + 'base_headers={}, timeout=None, method=POST, auth=None)')
+
+@patch('requests.sessions.Session.send')
+def test_basic_auth(mock_requests_send):
+    '[Requests] - Test if basic usage with only auth works'
+
+    configure_mock_requests_send(mock_requests_send, graphql_response_ok)
+
+    endpoint = RequestsEndpoint(test_url, 
+               auth=requests.auth.HTTPBasicAuth("user", "password"))
+    data = endpoint(graphql_query)
+    eq_(data, json.loads(graphql_response_ok))
+    check_mock_requests_send(mock_requests_send)
+    eq_(str(endpoint),
+        'RequestsEndpoint('
+        + 'url={}, '.format(test_url)
+        + 'base_headers={}, timeout=None, method=POST, auth=<class \'requests.auth.HTTPBasicAuth\'>)')
+
+
+
+@patch('requests.sessions.Session.send')
+def test_basic_bytes_query(mock_requests_send):
+    '[Requests] - Test if query with type bytes works'
+
+    configure_mock_requests_send(mock_requests_send, graphql_response_ok)
+
+    endpoint = RequestsEndpoint(test_url)
+    data = endpoint(graphql_query.encode('utf-8'))
+    eq_(data, json.loads(graphql_response_ok))
+    check_mock_requests_send(mock_requests_send)
+
+
+@patch('requests.sessions.Session.send')
+def test_basic_operation_query(mock_requests_send):
+    '[Requests] - Test if query with type sgqlc.operation.Operation() works'
+
+    configure_mock_requests_send(mock_requests_send, graphql_response_ok)
+
+    schema = Schema()
+
+    # MyType and Query may be declared if doctests were processed by nose
+    if 'MyType' in schema:
+        schema -= schema.MyType
+
+    if 'Query' in schema:
+        schema -= schema.Query
+
+    class MyType(Type):
+        __schema__ = schema
+        i = int
+
+    class Query(Type):
+        __schema__ = schema
+        my_type = MyType
+
+    op = Operation(Query)
+    op.my_type.i()
+
+    endpoint = RequestsEndpoint(test_url)
+    data = endpoint(op)
+    eq_(data, json.loads(graphql_response_ok))
+    check_mock_requests_send(mock_requests_send, query=bytes(op))
+
+
+@patch('requests.sessions.Session.send')
+def test_headers(mock_requests_send):
+    '[Requests] - Test if all headers are passed'
+
+    configure_mock_requests_send(mock_requests_send, graphql_response_ok)
+
+    base_headers = {
+        'Xpto': 'abc',
+    }
+    extra_headers = {
+        'Extra': '123',
+        'Accept': extra_accept_header,
+    }
+
+    endpoint = RequestsEndpoint(test_url, base_headers=base_headers)
+    data = endpoint(graphql_query, extra_headers=extra_headers)
+    eq_(data, json.loads(graphql_response_ok))
+    check_mock_requests_send(mock_requests_send,
+                             base_headers=base_headers,
+                             extra_headers=extra_headers)
+
+
+@patch('requests.sessions.Session.send')
+def test_default_timeout(mock_requests_send):
+    '[Requests] - Test if default timeout is respected'
+
+    configure_mock_requests_send(mock_requests_send, graphql_response_ok)
+
+    timeout = 123
+
+    endpoint = RequestsEndpoint(test_url, timeout=timeout)
+    data = endpoint(graphql_query)
+    eq_(data, json.loads(graphql_response_ok))
+    check_mock_requests_send(mock_requests_send, timeout=timeout)
+
+
+@patch('requests.sessions.Session.send')
+def test_call_timeout(mock_requests_send):
+    '[Requests] - Test if call timeout takes precedence over default'
+
+    configure_mock_requests_send(mock_requests_send, graphql_response_ok)
+
+    timeout = 123
+
+    endpoint = RequestsEndpoint(test_url, timeout=1)
+    data = endpoint(graphql_query, timeout=timeout)
+    eq_(data, json.loads(graphql_response_ok))
+    check_mock_requests_send(mock_requests_send, timeout=timeout)
+
+
+@patch('requests.sessions.Session.send')
+def test_variables(mock_requests_send):
+    '[Requests] - Test if variables are passed to server'
+
+    configure_mock_requests_send(mock_requests_send, graphql_response_ok)
+
+    variables = {'repoOwner': 'owner', 'repoName': 'name'}
+
+    endpoint = RequestsEndpoint(test_url)
+    data = endpoint(graphql_query, variables)
+    eq_(data, json.loads(graphql_response_ok))
+    check_mock_requests_send(mock_requests_send, variables=variables)
+
+
+@patch('requests.sessions.Session.send')
+def test_operation_name(mock_requests_send):
+    '[Requests] - Test if operation name is passed to server'
+
+    configure_mock_requests_send(mock_requests_send, graphql_response_ok)
+
+    operation_name = 'xpto'
+
+    endpoint = RequestsEndpoint(test_url)
+    data = endpoint(graphql_query, operation_name=operation_name)
+    eq_(data, json.loads(graphql_response_ok))
+    check_mock_requests_send(mock_requests_send, operation_name=operation_name)
+
+
+@patch('requests.sessions.Session.send')
+def test_json_error(mock_requests_send):
+    '[Requests] - Test if broken server responses (invalid JSON) is handled'
+
+    configure_mock_requests_send(mock_requests_send, 
+                                 graphql_response_json_error)
+
+    endpoint = RequestsEndpoint(test_url)
+    data = endpoint(graphql_query)
+
+    exc = get_json_exception(graphql_response_json_error)
+    got_exc = data['errors'][0].pop('exception')
+    assert isinstance(got_exc, json.JSONDecodeError), \
+        '{} is not json.JSONDecodeError'.format(type(got_exc))
+
+    eq_(data, {
+        'errors': [{
+            'message': str(exc),
+            'body': graphql_response_json_error,
+        }],
+        'data': None,
+    })
+    check_mock_requests_send(mock_requests_send)
+
+
+@patch('requests.sessions.Session.send')
+def test_get(mock_requests_send):
+    '[Requests] - Test if HTTP method GET request works'
+
+    configure_mock_requests_send(mock_requests_send, graphql_response_ok)
+
+    base_headers = {
+        'Xpto': 'abc',
+    }
+    extra_headers = {
+        'Extra': '123',
+        'Accept': extra_accept_header,
+    }
+    variables = {'repoOwner': 'owner', 'repoName': 'name'}
+    operation_name = 'xpto'
+
+    endpoint = RequestsEndpoint(test_url,
+                                base_headers=base_headers,
+                                method='GET')
+    data = endpoint(graphql_query,
+                    extra_headers=extra_headers,
+                    variables=variables,
+                    operation_name=operation_name,
+                    )
+    eq_(data, json.loads(graphql_response_ok))
+    check_mock_requests_send(mock_requests_send,
+                             method='GET',
+                             base_headers=base_headers,
+                             extra_headers=extra_headers,
+                             variables=variables,
+                             operation_name=operation_name,
+                             )
+    eq_(str(endpoint),
+        'RequestsEndpoint('
+        + 'url={}, '.format(test_url)
+        + 'base_headers={}, '.format(base_headers)
+        + 'timeout=None, method=GET, auth=None)',
+        )
+
+
+@patch('requests.sessions.Session.send')
+def test_server_reported_error(mock_requests_send):
+    '[Requests] - Test if GraphQL errors reported with HTTP 200 is handled'
+
+    configure_mock_requests_send(mock_requests_send, graphql_response_error)
+
+    endpoint = RequestsEndpoint(test_url)
+    data = endpoint(graphql_query)
+    eq_(data, json.loads(graphql_response_error))
+    check_mock_requests_send(mock_requests_send)
+
+
+@patch('requests.sessions.Session.send')
+def test_server_http_error(mock_requests_send):
+    '[Requests] - Test if HTTP error without JSON payload is handled'
+
+    res = requests.Response()
+    res.status_code = 500
+    res.url = test_url
+    res.reason = 'Some Error'
+    res.headers = {'Xpto': 'abc'}
+    res.raw = io.BytesIO(b'xpto')
+    err = requests.exceptions.HTTPError(response=res)
+    configure_mock_requests_send(mock_requests_send, err)
+
+    endpoint = RequestsEndpoint(test_url)
+    data = endpoint(graphql_query)
+    eq_(data, {
+        'errors': [{
+            'message': str(err),
+            'exception': err,
+            'status': 500,
+            'headers': {'Xpto': 'abc'},
+            'body': 'xpto',
+        }],
+        'data': None,
+    })
+    check_mock_requests_send(mock_requests_send)
+
+
+@patch('requests.sessions.Session.send')
+def test_server_http_non_conforming_json(mock_requests_send):
+    '[Requests] - Test HTTP error that is NOT conforming to GraphQL payload'
+
+    res = requests.Response()
+    res.status_code = 500
+    res.url = test_url
+    res.reason = 'Some Error'
+    res.headers = {'Content-Type': 'application/json'}
+    res.raw = io.BytesIO(b'{"message": "xpto"}')
+    err = requests.exceptions.HTTPError(response=res)
+    configure_mock_requests_send(mock_requests_send, err)
+
+    endpoint = RequestsEndpoint(test_url)
+    data = endpoint(graphql_query)
+    eq_(data, {
+        'errors': [{
+            'message': str(err),
+            'exception': err,
+            'status': 500,
+            'headers': {'Content-Type': 'application/json'},
+            'body': '{"message": "xpto"}',
+        }],
+        'data': None,
+    })
+    check_mock_requests_send(mock_requests_send)
+
+
+@patch('requests.sessions.Session.send')
+def test_server_error_broken_json(mock_requests_send):
+    '[Requests] - Test if HTTP error with broken JSON payload is handled'
+
+    res = requests.Response()
+    res.status_code = 500
+    res.url = test_url
+    res.reason = 'Some Error'
+    res.headers = {'Content-Type': 'application/json'}
+    res.raw = io.BytesIO(b'xpto')
+    err = requests.exceptions.HTTPError(response=res)
+    configure_mock_requests_send(mock_requests_send, err)
+
+    endpoint = RequestsEndpoint(test_url)
+    data = endpoint(graphql_query)
+    got_exc = data['errors'][0].pop('exception')
+    assert isinstance(got_exc, json.JSONDecodeError), \
+        '{} is not json.JSONDecodeError'.format(type(got_exc))
+
+    eq_(data, {
+        'errors': [{
+            'message': str(got_exc),
+            'body': 'xpto',
+        }],
+        'data': None,
+    })
+    check_mock_requests_send(mock_requests_send)
+
+
+@patch('requests.sessions.Session.send')
+def test_server_http_graphql_error(mock_requests_send):
+    '[Requests] - Test HTTP error that IS conforming to GraphQL payload'
+
+    res = requests.Response()
+    res.status_code = 500
+    res.url = test_url
+    res.reason = 'Some Error'
+    res.headers = {'Content-Type': 'application/json'}
+    res.raw = io.BytesIO(graphql_response_error.encode())
+    err = requests.exceptions.HTTPError(response=res)
+    configure_mock_requests_send(mock_requests_send, err)
+
+    endpoint = RequestsEndpoint(test_url)
+    data = endpoint(graphql_query)
+
+    expected_data = json.loads(graphql_response_error)
+    expected_data.update({
+        'exception': err,
+        'status': 500,
+        'headers': {'Content-Type': 'application/json'},
+    })
+
+    eq_(data, expected_data)
+    check_mock_requests_send(mock_requests_send)
+
+
+@patch('requests.sessions.Session.send')
+def test_server_http_single_error(mock_requests_send):
+    '[Requests] - Test HTTP error that a single JSON error string'
+
+    res = requests.Response()
+    res.status_code = 500
+    res.url = test_url
+    res.reason = 'Some Error'
+    res.headers = {'Content-Type': 'application/json'}
+    res.raw = io.BytesIO(b'{"errors": "a string"}')
+    err = requests.exceptions.HTTPError(response=res)
+    configure_mock_requests_send(mock_requests_send, err)
+
+    endpoint = RequestsEndpoint(test_url)
+    data = endpoint(graphql_query)
+
+    expected_data = {'errors': [{'message': 'a string'}]}
+    expected_data.update({
+        'exception': err,
+        'status': 500,
+        'headers': {'Content-Type': 'application/json'},
+    })
+
+    eq_(data, expected_data)
+    check_mock_requests_send(mock_requests_send)
+
+
+@patch('requests.sessions.Session.send')
+def test_server_http_error_string_list(mock_requests_send):
+    '[Requests] - Test if HTTP error that a JSON error string list is handled'
+
+    res = requests.Response()
+    res.status_code = 500
+    res.url = test_url
+    res.reason = 'Some Error'
+    res.headers = {'Content-Type': 'application/json'}
+    res.raw = io.BytesIO(b'{"errors": ["a", "b"]}')
+    err = requests.exceptions.HTTPError(response=res)
+    configure_mock_requests_send(mock_requests_send, err)
+
+    endpoint = RequestsEndpoint(test_url)
+    data = endpoint(graphql_query)
+
+    expected_data = {'errors': [{'message': 'a'}, {'message': 'b'}]}
+    expected_data.update({
+        'exception': err,
+        'status': 500,
+        'headers': {'Content-Type': 'application/json'},
+    })
+
+    eq_(data, expected_data)
+    check_mock_requests_send(mock_requests_send)
+
+
+@patch('requests.sessions.Session.send')
+def test_server_http_error_list_message(mock_requests_send):
+    '[Requests] - Test HTTP JSON error with messages being a list'
+
+    res = requests.Response()
+    res.status_code = 500
+    res.url = test_url
+    res.reason = 'Some Error'
+    res.headers = {'Content-Type': 'application/json'}
+    res.raw = io.BytesIO(b'{"errors": [{"message": [1, 2]}]}')
+    err = requests.exceptions.HTTPError(response=res)
+    configure_mock_requests_send(mock_requests_send, err)
+
+    endpoint = RequestsEndpoint(test_url)
+    data = endpoint(graphql_query)
+
+    expected_data = {'errors': [{'message': '[1, 2]'}]}
+    expected_data.update({
+        'exception': err,
+        'status': 500,
+        'headers': {'Content-Type': 'application/json'},
+    })
+
+    eq_(data, expected_data)
+    check_mock_requests_send(mock_requests_send)
+
+
+# add_query_to_url():
+# test paths not already tested, here just the repeated query
+
+
+def test_add_query_to_url_dict_of_list():
+    '[Requests] - Test add_query_to_url() with extra_query as a dict-of-list'
+
+    url = add_query_to_url('http://domain.com?a=1&a=2', {'a': ['3', '4']})
+    eq_(url, 'http://domain.com?a=1&a=2&a=3&a=4')
+
+
+def test_add_query_to_url_sequence():
+    '[Requests] - Test add_query_to_url() with extra_query as pairs'
+
+    u = add_query_to_url('http://domain.com?a=1&a=2', (('a', '3'), ('a', '4')))
+    eq_(u, 'http://domain.com?a=1&a=2&a=3&a=4')


### PR DESCRIPTION
Hey,

 As discussed, pull request to address #69.

The functionality change is very minimal and only new addition is the option to add a requests.auth compliant authentication to the Endpoint.

I didn't touch the examples / main documentation to make the PR less obtrusive. But happy to update main docs and provide an example if desired.