### PR TITLE
Make field names explicit

### DIFF
--- a/bin/sgqlc-codegen
+++ b/bin/sgqlc-codegen
@@ -326,7 +326,7 @@ default=%(default)s)),
 
     def write_type_input_object(self, t):
         name = t['name']
-        field_names = [self.graphql_to_python(f['name']) for f in t['inputFields']]
+        field_names = tuple(self.graphql_to_python(f['name']) for f in t['inputFields'])
         self.writer('''\
 class %(name)s(sgqlc.types.Input):
     __schema__ = %(schema_name)s

--- a/bin/sgqlc-codegen
+++ b/bin/sgqlc-codegen
@@ -324,12 +324,15 @@ default=%(default)s)),
 
     def write_type_input_object(self, t):
         name = t['name']
+        field_names = [self.graphql_to_python(f['name']) for f in t['inputFields']]
         self.writer('''\
 class %(name)s(sgqlc.types.Input):
     __schema__ = %(schema_name)s
+    __field_names__ = %(field_names)s
 ''' % {
             'name': name,
             'schema_name': self.schema_name,
+            'field_names': field_names,
         })
         for field in t['inputFields']:
             self.write_field_input(field)

--- a/sgqlc/types/__init__.py
+++ b/sgqlc/types/__init__.py
@@ -1524,16 +1524,20 @@ class ContainerTypeMeta(BaseMetaWithTypename):
         for b in bases:
             cls.__fields.update(b.__fields)
 
+    def __get_field_names(cls):
+        implicit_members = super(ContainerTypeMeta, cls).__dir__()
+        explicit_members = getattr(cls, "__field_names__", tuple())
+        return (
+            name
+            for name in implicit_members
+            if not name.startswith("_")
+            or (name in getattr(cls, "__field_names__", []))
+        )
+
     def __create_own_fields(cls):
         # call the parent __dir__(), we don't want our overridden version
         # that reports fields we're just deleting
-        members = super(ContainerTypeMeta, cls).__dir__()
-        for name in members:
-            if name.startswith("_") and (
-                name not in getattr(cls, "__field_names__", [])
-            ):
-                continue
-
+        for name in cls.__get_field_names():
             field = getattr(cls, name)
             if not isinstance(field, Field):
                 if not isinstance(field, Lazy):

--- a/sgqlc/types/__init__.py
+++ b/sgqlc/types/__init__.py
@@ -1531,7 +1531,7 @@ class ContainerTypeMeta(BaseMetaWithTypename):
             name
             for name in implicit_members
             if not name.startswith("_")
-            or (name in getattr(cls, "__field_names__", []))
+            or (name in explicit_members)
         )
 
     def __create_own_fields(cls):

--- a/sgqlc/types/__init__.py
+++ b/sgqlc/types/__init__.py
@@ -1526,7 +1526,7 @@ class ContainerTypeMeta(BaseMetaWithTypename):
 
     def __get_field_names(cls):
         implicit_members = super(ContainerTypeMeta, cls).__dir__()
-        explicit_members = getattr(cls, "__field_names__", tuple())
+        explicit_members = getattr(cls, "__field_names__", ())
         return (
             name
             for name in implicit_members

--- a/sgqlc/types/__init__.py
+++ b/sgqlc/types/__init__.py
@@ -1529,7 +1529,7 @@ class ContainerTypeMeta(BaseMetaWithTypename):
         # that reports fields we're just deleting
         members = super(ContainerTypeMeta, cls).__dir__()
         for name in members:
-            if name.startswith('_') and (name not in ["_and" ,"_or" ,"_not" , "_eq" ,"_gt" ,"_gte" ,"_ilike" ,"_in" ,"_is_null" ,"_like" ,"_lt" ,"_lte" ,"_neq" ,"_nilike" ,"_nin" ,"_nlike" ,"_nsimilar" ,"_similar"]):
+            if name.startswith('_') and (name not in getattr(cls, '__field_names__', [])):
                 continue
 
             field = getattr(cls, name)

--- a/sgqlc/types/__init__.py
+++ b/sgqlc/types/__init__.py
@@ -1529,7 +1529,9 @@ class ContainerTypeMeta(BaseMetaWithTypename):
         # that reports fields we're just deleting
         members = super(ContainerTypeMeta, cls).__dir__()
         for name in members:
-            if name.startswith('_') and (name not in getattr(cls, '__field_names__', [])):
+            if name.startswith("_") and (
+                name not in getattr(cls, "__field_names__", [])
+            ):
                 continue
 
             field = getattr(cls, name)

--- a/sgqlc/types/__init__.py
+++ b/sgqlc/types/__init__.py
@@ -1529,7 +1529,7 @@ class ContainerTypeMeta(BaseMetaWithTypename):
         # that reports fields we're just deleting
         members = super(ContainerTypeMeta, cls).__dir__()
         for name in members:
-            if name.startswith('_'):
+            if name.startswith('_') and (name not in ["_and" ,"_or" ,"_not" , "_eq" ,"_gt" ,"_gte" ,"_ilike" ,"_in" ,"_is_null" ,"_like" ,"_lt" ,"_lte" ,"_neq" ,"_nilike" ,"_nin" ,"_nlike" ,"_nsimilar" ,"_similar"]):
                 continue
 
             field = getattr(cls, name)


### PR DESCRIPTION
This change allows to define field names explicitly via the `__field_names__` class attribute.

This permits the existence of fields that begin with `_` without conflicting with for example.

The codegen was updated to include this change in order enable the generation of Hasura compatible schemas.

Fixes #81 