### PR TITLE
Do more work for Python 3.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     author_email='barbieri@profusion.mobi',
     url='http://github.com/profusion/sgqlc',
     license='ISCL',
-    python_requires='>=3.6',
+    python_requires='>=3.5',
     requires=[],
     install_requires=['graphql-core'],
     extras_require={

--- a/sgqlc/endpoint/websocket.py
+++ b/sgqlc/endpoint/websocket.py
@@ -79,14 +79,14 @@ class WebSocketEndpoint(BaseEndpoint):
             response = self._get_response(ws)
             if response['type'] != 'connection_ack':
                 raise ValueError(
-                    f'Unexpected {response["type"]} '
-                    f'when waiting for connection ack'
+                    'Unexpected {} '
+                    'when waiting for connection ack'.format(response["type"])
                 )
             # response does not always have an id
             if response.get('id', init_id) != init_id:
                 raise ValueError(
-                    f'Unexpected id {response["id"]} '
-                    f'when waiting for connection ack'
+                    'Unexpected id {} '
+                    'when waiting for connection ack'.format(response["id"])
                 )
 
             query_id = self.generate_id()
@@ -99,14 +99,16 @@ class WebSocketEndpoint(BaseEndpoint):
             while response['type'] != 'complete':
                 if response['id'] != query_id:
                     raise ValueError(
-                        f'Unexpected id {response["id"]} '
-                        f'when waiting for query results'
+                        'Unexpected id {} '
+                        'when waiting for query results'.format(response["id"])
                     )
                 if response['type'] == 'data':
                     yield response['payload']
                 else:
-                    raise ValueError(f'Unexpected message {response} '
-                                     f'when waiting for query results')
+                    raise ValueError(
+                        'Unexpected message {} '
+                        'when waiting for query results'.format(response)
+                    )
                 response = self._get_response(ws)
 
         finally:

--- a/sgqlc/types/datetime.py
+++ b/sgqlc/types/datetime.py
@@ -50,7 +50,7 @@ time2 datetime.time(12, 34, 56, tzinfo=...(days=-1, seconds=75600)))
 date1 datetime.date(2018, 1, 2)
 date2 datetime.date(2018, 1, 2)
 datetime1 datetime.datetime(2018, 1, 2, 12, 34, 56, tzinfo=....utc)
-datetime2 datetime.datetime(2018, 1, 2, 12, 34, 56, tzinfo=...seconds=75600)))
+datetime2 datetime.datetime(2018, 1, 2, 12, 34, 56, tzinfo=...75600)))
 
 Pre-converted types are allowed:
 
@@ -101,17 +101,17 @@ class Time(Scalar):
     >>> Time('12:34:56Z') # Z = GMT/UTC
     datetime.time(12, 34, 56, tzinfo=datetime.timezone.utc)
     >>> Time('12:34:56-05:30') # doctest: +ELLIPSIS
-    datetime.time(12, 34, 56, tzinfo=...(days=-1, seconds=70200)))
+    datetime.time(12, 34, 56, tzinfo=...(...-1, ...70200)))
     >>> Time('12:34:56+05:30') # doctest: +ELLIPSIS
-    datetime.time(12, 34, 56, tzinfo=...(seconds=19800)))
+    datetime.time(12, 34, 56, tzinfo=...(...19800)))
     >>> Time('123456') # compact form
     datetime.time(12, 34, 56)
     >>> Time('123456Z') # compact form, GMT/UTC
     datetime.time(12, 34, 56, tzinfo=datetime.timezone.utc)
     >>> Time('123456-0530') # doctest: +ELLIPSIS
-    datetime.time(12, 34, 56, tzinfo=...(days=-1, seconds=70200)))
+    datetime.time(12, 34, 56, tzinfo=...(...-1, ...70200)))
     >>> Time('123456+0530') # doctest: +ELLIPSIS
-    datetime.time(12, 34, 56, tzinfo=...(seconds=19800)))
+    datetime.time(12, 34, 56, tzinfo=...(...19800)))
 
     Pre-converted values are allowed:
 
@@ -230,17 +230,17 @@ class DateTime(Scalar):
     >>> DateTime('2018-01-02T12:34:56Z') # Z = GMT/UTC
     datetime.datetime(2018, 1, 2, 12, 34, 56, tzinfo=datetime.timezone.utc)
     >>> DateTime('2018-01-02T12:34:56-05:30') # doctest: +ELLIPSIS
-    datetime.datetime(2018, 1, 2, 12, 34, 56, tzinfo=..., seconds=70200)))
+    datetime.datetime(2018, 1, 2, 12, 34, 56, tzinfo=...70200)))
     >>> DateTime('2018-01-02T12:34:56+05:30') # doctest: +ELLIPSIS
-    datetime.datetime(2018, 1, 2, 12, 34, 56, tzinfo=...(seconds=19800)))
+    datetime.datetime(2018, 1, 2, 12, 34, 56, tzinfo=...(...19800)))
     >>> DateTime('20180102T123456') # compact form
     datetime.datetime(2018, 1, 2, 12, 34, 56)
     >>> DateTime('20180102T123456Z') # compact form, GMT/UTC
     datetime.datetime(2018, 1, 2, 12, 34, 56, tzinfo=datetime.timezone.utc)
     >>> DateTime('20180102T123456-0530') # doctest: +ELLIPSIS
-    datetime.datetime(2018, 1, 2, 12, 34, 56, tzinfo=..., seconds=70200)))
+    datetime.datetime(2018, 1, 2, 12, 34, 56, tzinfo=...70200)))
     >>> DateTime('20180102T123456+0530') # doctest: +ELLIPSIS
-    datetime.datetime(2018, 1, 2, 12, 34, 56, tzinfo=...(seconds=19800)))
+    datetime.datetime(2018, 1, 2, 12, 34, 56, tzinfo=...(...19800)))
 
     Pre-converted values are allowed:
 

--- a/tests/test-endpoint-http.py
+++ b/tests/test-endpoint-http.py
@@ -29,7 +29,7 @@ query GitHubRepoIssues($repoOwner: String!, $repoName: String!) {
 }
 '''
 
-graphql_response_ok = b'''
+graphql_response_ok = '''
 {
   "data": {
     "repository": {
@@ -45,7 +45,7 @@ graphql_response_ok = b'''
   }
 }'''
 
-graphql_response_error = b'''
+graphql_response_error = '''
 {
   "errors": [{
     "message": "Server Reported Error",
@@ -57,7 +57,7 @@ graphql_response_error = b'''
 }
 '''
 
-graphql_response_json_error = b'''
+graphql_response_json_error = '''
 {
   "data": {
 '''
@@ -77,7 +77,7 @@ def configure_mock_urlopen(mock_urlopen, payload):
     if isinstance(payload, Exception):
         mock_urlopen.side_effect = payload
     else:
-        mock_urlopen.return_value = io.BytesIO(payload)
+        mock_urlopen.return_value = io.BytesIO(payload.encode('utf-8'))
 
 
 def check_request_url(req, expected):
@@ -124,7 +124,7 @@ def get_request_url_query(req):
 
 def check_request_variables(req, variables):
     if req.method == 'POST':
-        post_data = json.loads(req.data)
+        post_data = json.loads(req.data.decode('utf-8'))
         received = post_data.get('variables')
     else:
         query = get_request_url_query(req)
@@ -135,7 +135,7 @@ def check_request_variables(req, variables):
 
 def check_request_operation_name(req, operation_name):
     if req.method == 'POST':
-        post_data = json.loads(req.data)
+        post_data = json.loads(req.data.decode('utf-8'))
         received = post_data.get('operationName')
     else:
         query = get_request_url_query(req)
@@ -146,7 +146,7 @@ def check_request_operation_name(req, operation_name):
 
 def check_request_query(req, query):
     if req.method == 'POST':
-        post_data = json.loads(req.data)
+        post_data = json.loads(req.data.decode('utf-8'))
         received = post_data.get('query')
     else:
         query_data = get_request_url_query(req)
@@ -337,7 +337,7 @@ def test_json_error(mock_urlopen):
     eq_(data, {
         'errors': [{
             'message': str(exc),
-            'body': graphql_response_json_error.decode('utf-8'),
+            'body': graphql_response_json_error,
         }],
         'data': None,
     })
@@ -488,7 +488,7 @@ def test_server_http_graphql_error(mock_urlopen):
         500,
         'Some Error',
         {'Content-Type': 'application/json'},
-        io.BytesIO(graphql_response_error),
+        io.BytesIO(graphql_response_error.encode('utf-8')),
     )
     configure_mock_urlopen(mock_urlopen, err)
 

--- a/tests/test-endpoint-requests.py
+++ b/tests/test-endpoint-requests.py
@@ -144,7 +144,7 @@ def get_request_url_query(req):
 
 def check_request_variables(req, variables):
     if req.method == 'POST':
-        post_data = json.loads(req.body)
+        post_data = json.loads(req.body.decode('utf-8'))
         received = post_data.get('variables')
     else:
         query = get_request_url_query(req)
@@ -155,7 +155,7 @@ def check_request_variables(req, variables):
 
 def check_request_operation_name(req, operation_name):
     if req.method == 'POST':
-        post_data = json.loads(req.body)
+        post_data = json.loads(req.body.decode('utf-8'))
         received = post_data.get('operationName')
     else:
         query = get_request_url_query(req)
@@ -166,7 +166,7 @@ def check_request_operation_name(req, operation_name):
 
 def check_request_query(req, query):
     if req.method == 'POST':
-        post_data = json.loads(req.body)
+        post_data = json.loads(req.body.decode('utf-8'))
         received = post_data.get('query')
     else:
         query_data = get_request_url_query(req)


### PR DESCRIPTION
It turns out that the way things are set up on the project I want to use sgqlc for will make it difficult to use `pip install --ignore-requires-python`, so I've done a bit more fixing of the tests for 3.5, hopefully enough to give you enough confidence to allow `setup.py` to declare compatibility with Python 3.5. There are a number of remaining test failures, but I'm pretty sure they're all related to the ordering of fields or arguments when types or arguments are printed in the GraphQL format; that breaks the doctests, but I don't imagine it will have much effect in practice. I'd be happy to address that issue too, but I couldn't figure out how; if you give me some pointers, I'll take a look.
