### PR TITLE
Fix/codegen operation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,16 @@ jobs:
     - name: Build
       run: |
         ./setup.py egg_info -Db '' sdist bdist_egg
+    - name: Install
+      run: |
+        ./setup.py install --skip-build
+    - name: Test GitHub example
+      run: |
+        cd examples/github
+        NO_DOWNLOAD=1 ./update-schema.sh
+        ./update-operations.sh
+    - name: Test Shopify example
+      run: |
+        cd examples/shopify
+        NO_DOWNLOAD=1 ./update-schema.sh
+        ./update-operations.sh

--- a/examples/github/sample_operations.gql
+++ b/examples/github/sample_operations.gql
@@ -2,7 +2,7 @@ query ListIssues($owner: String!, $name: String!) {
     repository(owner: $owner, name: $name) {
         issues(first: 100) {
             nodes {
-                number
+                n: number
                 title
             }
             pageInfo {

--- a/examples/github/sample_operations.py
+++ b/examples/github/sample_operations.py
@@ -10,7 +10,7 @@ def query_list_issues():
     _op_repository = _op.repository(owner=sgqlc.types.Variable('owner'), name=sgqlc.types.Variable('name'))
     _op_repository_issues = _op_repository.issues(first=100)
     _op_repository_issues_nodes = _op_repository_issues.nodes()
-    _op_repository_issues_nodes.number()
+    _op_repository_issues_nodes.number(__alias__='n')
     _op_repository_issues_nodes.title()
     _op_repository_issues_page_info = _op_repository_issues.page_info()
     _op_repository_issues_page_info.has_next_page()

--- a/examples/github/sample_operations.py
+++ b/examples/github/sample_operations.py
@@ -2,11 +2,14 @@ import sgqlc.types
 import sgqlc.operation
 import github_schema
 
+_schema = github_schema
+_schema_root = _schema.github_schema
+
 __all__ = ('Operations',)
 
 
 def query_list_issues():
-    _op = sgqlc.operation.Operation(github_schema.github_schema.query_type, name='ListIssues', variables=dict(owner=sgqlc.types.Arg(sgqlc.types.non_null(github_schema.github_schema.String)), name=sgqlc.types.Arg(sgqlc.types.non_null(github_schema.github_schema.String))))
+    _op = sgqlc.operation.Operation(_schema_root.query_type, name='ListIssues', variables=dict(owner=sgqlc.types.Arg(sgqlc.types.non_null(github_schema.github_schema.String)), name=sgqlc.types.Arg(sgqlc.types.non_null(github_schema.github_schema.String))))
     _op_repository = _op.repository(owner=sgqlc.types.Variable('owner'), name=sgqlc.types.Variable('name'))
     _op_repository_issues = _op_repository.issues(first=100)
     _op_repository_issues_nodes = _op_repository_issues.nodes()

--- a/examples/github/update-schema.sh
+++ b/examples/github/update-schema.sh
@@ -1,17 +1,19 @@
 #!/bin/sh
 
-if [ -z "$GH_TOKEN" ]; then
-    echo "please export GH_TOKEN with your GitHub API token" >&2
-    echo "see: https://github.com/settings/tokens" >&2
-    exit 1
-fi
+if [ "$NO_DOWNLOAD" != 1 ]; then
+    if [ -z "$GH_TOKEN" ]; then
+        echo "please export GH_TOKEN with your GitHub API token" >&2
+        echo "see: https://github.com/settings/tokens" >&2
+        exit 1
+    fi
 
-python3 \
-    -m sgqlc.introspection \
-    --exclude-deprecated \
-    --exclude-description \
-    -H "Authorization: bearer ${GH_TOKEN}" \
-    https://api.github.com/graphql \
-    github_schema.json || exit 1
+    python3 \
+        -m sgqlc.introspection \
+        --exclude-deprecated \
+        --exclude-description \
+        -H "Authorization: bearer ${GH_TOKEN}" \
+        https://api.github.com/graphql \
+        github_schema.json || exit 1
+fi
 
 sgqlc-codegen schema github_schema.json github_schema.py

--- a/examples/shopify/shopify_operations.py
+++ b/examples/shopify/shopify_operations.py
@@ -2,11 +2,14 @@ import sgqlc.types
 import sgqlc.operation
 import shopify_schema
 
+_schema = shopify_schema
+_schema_root = _schema.shopify_schema
+
 __all__ = ('Operations',)
 
 
 def fragment_select_products():
-    _frag = sgqlc.operation.Fragment(shopify_schema.ProductConnection, 'SelectProducts')
+    _frag = sgqlc.operation.Fragment(_schema.ProductConnection, 'SelectProducts')
     _frag_page_info = _frag.page_info()
     _frag_page_info.has_next_page()
     _frag_edges = _frag.edges()
@@ -26,7 +29,7 @@ def fragment_select_products():
 
 
 def fragment_money():
-    _frag = sgqlc.operation.Fragment(shopify_schema.MoneyV2, 'Money')
+    _frag = sgqlc.operation.Fragment(_schema.MoneyV2, 'Money')
     _frag.amount()
     _frag.currency_code()
     return _frag
@@ -38,7 +41,7 @@ class Fragment:
 
 
 def query_initial_query():
-    _op = sgqlc.operation.Operation(shopify_schema.shopify_schema.query_type, name='InitialQuery', variables=dict(first=sgqlc.types.Arg(sgqlc.types.non_null(shopify_schema.shopify_schema.Int)), after=sgqlc.types.Arg(shopify_schema.shopify_schema.String, default=None)))
+    _op = sgqlc.operation.Operation(_schema_root.query_type, name='InitialQuery', variables=dict(first=sgqlc.types.Arg(sgqlc.types.non_null(shopify_schema.shopify_schema.Int)), after=sgqlc.types.Arg(shopify_schema.shopify_schema.String, default=None)))
     _op_shop = _op.shop()
     _op_shop.name()
     _op_shop.description()
@@ -49,7 +52,7 @@ def query_initial_query():
 
 
 def query_load_products():
-    _op = sgqlc.operation.Operation(shopify_schema.shopify_schema.query_type, name='LoadProducts', variables=dict(first=sgqlc.types.Arg(sgqlc.types.non_null(shopify_schema.shopify_schema.Int)), after=sgqlc.types.Arg(sgqlc.types.non_null(shopify_schema.shopify_schema.String))))
+    _op = sgqlc.operation.Operation(_schema_root.query_type, name='LoadProducts', variables=dict(first=sgqlc.types.Arg(sgqlc.types.non_null(shopify_schema.shopify_schema.Int)), after=sgqlc.types.Arg(sgqlc.types.non_null(shopify_schema.shopify_schema.String))))
     _op_products = _op.products(first=sgqlc.types.Variable('first'), after=sgqlc.types.Variable('after'))
     _op_products.__fragment__(fragment_select_products())
     return _op

--- a/examples/shopify/update-schema.sh
+++ b/examples/shopify/update-schema.sh
@@ -1,18 +1,20 @@
 #!/bin/sh
 
-SHOP_STORE=${SHOP_STORE:-sgqlc-test}
-if [ -z "$SHOP_TOKEN" ]; then
-    echo "please export SHOP_TOKEN with your Shopify X-Shopify-Access-Token" >&2
-    echo "See https://shopify.dev/docs/admin-api/graphql/getting-started#authentication" >&2
-    exit 1
-fi
+if [ "$NO_DOWNLOAD" != 1 ]; then
+    SHOP_STORE=${SHOP_STORE:-sgqlc-test}
+    if [ -z "$SHOP_TOKEN" ]; then
+        echo "please export SHOP_TOKEN with your Shopify X-Shopify-Access-Token" >&2
+        echo "See https://shopify.dev/docs/admin-api/graphql/getting-started#authentication" >&2
+        exit 1
+    fi
 
-python3 \
-    -m sgqlc.introspection \
-    --exclude-deprecated \
-    --exclude-description \
-    -H "X-Shopify-Access-Token: ${SHOP_TOKEN}" \
-    https://${SHOP_STORE}.myshopify.com/admin/api/2020-10/graphql.json \
-    shopify_schema.json || exit 1
+    python3 \
+        -m sgqlc.introspection \
+        --exclude-deprecated \
+        --exclude-description \
+        -H "X-Shopify-Access-Token: ${SHOP_TOKEN}" \
+        https://${SHOP_STORE}.myshopify.com/admin/api/2020-10/graphql.json \
+        shopify_schema.json || exit 1
+fi
 
 sgqlc-codegen schema shopify_schema.json shopify_schema.py

--- a/sgqlc/codegen/operation.py
+++ b/sgqlc/codegen/operation.py
@@ -456,9 +456,11 @@ def fragment_%(name)s():
             if a['type']['kind'] == 'NON_NULL' and a['defaultValue'] is None:
                 required.add(a['name'])
 
-        for _, var in node.arguments:
-            if var.name in required:
-                required.remove(var.name)
+        for name, maybe_var in node.arguments:
+            if hasattr(maybe_var, 'name'):
+                name = maybe_var.name
+            if name in required:
+                required.remove(name)
 
         if required:
             raise ValueError(

--- a/sgqlc/codegen/operation.py
+++ b/sgqlc/codegen/operation.py
@@ -471,17 +471,16 @@ def fragment_%(name)s():
     def leave_field(self, node, *_args):
         self.validate_required_arguments(node)
 
+        args = node.arguments
         alias = ''
         if node.alias:
             alias = to_python_name(node.alias)
-            node.arguments.append(('__alias__', alias))
-
-        args = OrderedDict(node.arguments)
+            args = list(args) + [('__alias__', alias)]
 
         name = to_python_name(node.name)
         selection = '%(name)s(%(args)s)' % {
             'name': name,
-            'args': ', '.join('%s=%r' % a for a in args.items()),
+            'args': ', '.join('%s=%r' % a for a in args),
         }
         if not alias:
             alias = name

--- a/sgqlc/types/__init__.py
+++ b/sgqlc/types/__init__.py
@@ -973,6 +973,9 @@ def _create_list_of_wrapper(name, t):
         return [realize_type(v, selection_list) for v in json_data]
 
     def __to_graphql_input__(value, indent=0, indent_string='  '):
+        if isinstance(value, Variable):
+            return value.__to_graphql_input__(value, indent, indent_string)
+
         r = []
         for v in value:
             v = realize_type(v)
@@ -2246,20 +2249,20 @@ class ArgDict(OrderedDict):
     Note that for better understanding, more than 3 arguments are
     printed in multiple lines:
 
-    >>> ad = ArgDict(a=int, b=float, c=str, d=list_of(int))
+    >>> ad = ArgDict(a=int, b=float, c=non_null(str), d=list_of(int))
     >>> ad._set_container(global_schema, None)  # done automatically by Field
     >>> print(ad)
     (
       a: Int
       b: Float
-      c: String
+      c: String!
       d: [Int]
     )
     >>> print(bytes(ad).decode('utf-8'))
     (
     a: Int
     b: Float
-    c: String
+    c: String!
     d: [Int]
     )
 
@@ -2273,6 +2276,21 @@ class ArgDict(OrderedDict):
         b: 2.2
         c: "hi"
         d: [1, 2]
+      )
+
+    Variables can be handled using :class:`Variable` instances:
+
+    >>> print('fieldName' + ad.__to_graphql_input__({
+    ...     'a': Variable('a'),
+    ...     'b': Variable('b'),
+    ...     'c': Variable('c'),
+    ...     'd': Variable('d'),
+    ... }))
+    fieldName(
+        a: $a
+        b: $b
+        c: $c
+        d: $d
       )
 
     '''

--- a/utils/git/pre-commit
+++ b/utils/git/pre-commit
@@ -61,7 +61,24 @@ function test_coverage {
     return 0
 }
 
+function check_examples {
+    if [ -z "$STAGED_PY_FILES" ]; then
+        echo "No python files changed, nothing to check in examples"
+        return 0
+    fi
+
+    (cd $BASE_PATH/examples/github &&
+        NO_DOWNLOAD=1 ./update-schema.sh &&
+        ./update-operations.sh &&
+        echo 'GitHub example Ok')
+    (cd $BASE_PATH/examples/shopify &&
+        NO_DOWNLOAD=1 ./update-schema.sh &&
+        ./update-operations.sh &&
+        echo 'Shopify example Ok')
+}
+
 cd $BASE_PATH
 test_dependencies &&
 call_flake8 &&
+check_examples &&
 test_coverage

--- a/utils/git/pre-push
+++ b/utils/git/pre-push
@@ -59,8 +59,20 @@ function do_release {
     return 0
 }
 
+function check_examples {
+    (cd $BASE_PATH/examples/github &&
+        NO_DOWNLOAD=1 ./update-schema.sh &&
+        ./update-operations.sh &&
+        echo 'GitHub example Ok')
+    (cd $BASE_PATH/examples/shopify &&
+        NO_DOWNLOAD=1 ./update-schema.sh &&
+        ./update-operations.sh &&
+        echo 'Shopify example Ok')
+}
+
 cd $BASE_PATH
 test_dependencies &&
 call_flake8 &&
 test_coverage &&
+check_examples &&
 do_release


### PR DESCRIPTION
Fix issues with the code generator.

One issue was introduced by #123, the other is the handling of aliases which was mutating the frozen list.

Operations codegen now also generates simpler code by using top level variables `_schema` and `_schema_root`.

Fix `__to_graphql_input__` when variables are used for list types, this was reported in #125 as well.

Setup CI so more tests are done, avoiding bugs such as introduced by PR #123.

Fixes: #125 