### PR TITLE
fix scalar variables

### DIFF
--- a/sgqlc/types/__init__.py
+++ b/sgqlc/types/__init__.py
@@ -1294,7 +1294,12 @@ class Scalar(BaseType):
         return value
 
     def __new__(cls, json_data, selection_list=None):
-        return None if json_data is None else cls.converter(json_data)
+        if json_data is None:
+            return None
+        elif isinstance(json_data, Variable):
+            return json_data
+        else:
+            return cls.converter(json_data)
 
     @classmethod
     def __to_graphql_input__(cls, value, indent=0, indent_string='  '):


### PR DESCRIPTION
Found one more bug, preventing the proper assignment of scalar arguments to the corresponding variables when using filters. Solution is similar to [fix list variables PR](https://github.com/profusion/sgqlc/pull/151).