### PR TITLE
Fix codegen to accept __typename

### DIFF
--- a/examples/github/sample_operations.gql
+++ b/examples/github/sample_operations.gql
@@ -5,6 +5,7 @@ query ListIssues(
     $filterStates: [IssueState!]=[OPEN]
 ) {
     repository(owner: $owner, name: $name) {
+        __typename
         issues(first: 100, orderBy: $desiredOrderBy, states: $filterStates) {
             nodes {
                 n: number

--- a/examples/github/sample_operations.py
+++ b/examples/github/sample_operations.py
@@ -11,6 +11,7 @@ __all__ = ('Operations',)
 def query_list_issues():
     _op = sgqlc.operation.Operation(_schema_root.query_type, name='ListIssues', variables=dict(owner=sgqlc.types.Arg(sgqlc.types.non_null(_schema.String)), name=sgqlc.types.Arg(sgqlc.types.non_null(_schema.String)), desiredOrderBy=sgqlc.types.Arg(_schema.IssueOrder, default={'field': 'CREATED_AT', 'direction': 'ASC'}), filterStates=sgqlc.types.Arg(sgqlc.types.list_of(sgqlc.types.non_null(_schema.IssueState)), default=['OPEN'])))
     _op_repository = _op.repository(owner=sgqlc.types.Variable('owner'), name=sgqlc.types.Variable('name'))
+    _op_repository.__typename__()
     _op_repository_issues = _op_repository.issues(first=100, order_by=sgqlc.types.Variable('desiredOrderBy'), states=sgqlc.types.Variable('filterStates'))
     _op_repository_issues_nodes = _op_repository_issues.nodes()
     _op_repository_issues_nodes.number(__alias__='n')

--- a/sgqlc/codegen/operation.py
+++ b/sgqlc/codegen/operation.py
@@ -110,11 +110,24 @@ class SchemaValidation(NoValidation):
             return fallback
         return d
 
+    _typename_field = {
+        'args': {},
+        'description': 'GraphQL type name',
+        'name': '__typename',
+        'type': {
+            'kind': 'NON_NULL',
+            'name': None,
+            'ofType': {'kind': 'SCALAR', 'name': 'String', 'ofType': None},
+        },
+    }
+
     def _create_type(self, typ):
         fields = typ.get('fields') or typ.get('inputFields') or []
         typ['fields'] = {
             f['name']: self._create_field(f) for f in fields
         }
+        typ['fields'].setdefault('__typename', self._typename_field)
+
         if 'inputFields' in typ:
             del typ['inputFields']
 

--- a/sgqlc/operation/__init__.py
+++ b/sgqlc/operation/__init__.py
@@ -650,6 +650,22 @@ query {
   }
 }
 
+.. note::
+
+  The built-in object type ``__typename`` would cause issues with Python's
+  name mangling as it would be translated to the private class member name.
+  In order to avoid this issue, whenever selecting GraphQL's ``__typename``
+  use the ``__typename__`` Python name. Example:
+
+  >>> op = Operation(Query)
+  >>> op.repository(id='repo1').__typename__()
+  __typename
+  >>> op
+  query {
+    repository(id: "repo1") {
+      __typename
+    }
+  }
 
 
 


### PR DESCRIPTION
Schemas do not need to define __typename: String as it's always
there. However when converting it to_python, the name gains a `__`
suffix.

Also document `__typename` is to be written in Python as
`__typename__`.

Closes: #175