### PR TITLE
Missing ___init__ of super class

### DIFF
--- a/sgqlc/codegen/operation.py
+++ b/sgqlc/codegen/operation.py
@@ -308,6 +308,7 @@ class ParsedSchemaName(NamedTuple):
 
 class GraphQLToPython(Visitor):
     def __init__(self, validation, schema_name, short_names):
+        Visitor.__init__(self)
         self.validation = validation
         self.schema_name = schema_name
         self.short_names = short_names


### PR DESCRIPTION
Hi,
I think there is a missing call to __init___ of the parent class GraphQLToPython.

I could not run the  sgqlc.codegen operation at all.
I got a long traceback everytime that ended with:

    return self.enter_leave_map[kind]
AttributeError: 'GraphQLToPython' object has no attribute 'enter_leave_map'

I have done very minimal testing. But now the codegen creates a python file.




