### PR TITLE
json loading: open file in binary mode to support BOM

### DIFF
--- a/sgqlc/codegen/operation.py
+++ b/sgqlc/codegen/operation.py
@@ -891,12 +891,12 @@ def add_arguments(ap):
     )
     ap.add_argument(
         'operation.gql',
-        type=argparse.FileType('r'), nargs='*',
+        type=argparse.FileType('r', encoding='utf-8'), nargs='*',
         help='The input GraphQL (DSL) with operations',
         default=[sys.stdin],
     )
     ap.add_argument(
-        '--schema', type=argparse.FileType('r'),
+        '--schema', type=argparse.FileType('rb'),
         help=('The input schema as JSON file. '
               'Usually the output from introspection query. '
               'If given, the operations will be validated.'),
@@ -937,7 +937,9 @@ def handle_command(parsed_args):
     in_files = args['operation.gql']
     short_names = args['short_names']
 
-    operations_gql = [Source(f.read(), f.name) for f in in_files]
+    operations_gql = [
+        Source(f.read(), f.name) for f in in_files
+    ]
 
     gen = CodeGen(
         schema, schema_name, operations_gql,

--- a/sgqlc/codegen/schema.py
+++ b/sgqlc/codegen/schema.py
@@ -634,7 +634,7 @@ def load_schema(in_file):
 
 def add_arguments(ap):
     # Generic options to access the GraphQL API
-    ap.add_argument('schema.json', type=argparse.FileType('r'), nargs='?',
+    ap.add_argument('schema.json', type=argparse.FileType('rb'), nargs='?',
                     help=('The input schema as JSON file. '
                           'Usually the output from introspection query.'),
                     default=sys.stdin)


### PR DESCRIPTION
Otherwise fails with trace 
```
✗ sgqlc-codegen schema schema.json              
Writing to: schema.py
Traceback (most recent call last):
  File "/usr/local/bin/sgqlc-codegen", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.10/site-packages/sgqlc/codegen/__init__.py", line 130, in main
    args.func(args)
  File "/usr/local/lib/python3.10/site-packages/sgqlc/codegen/schema.py", line 676, in handle_command
    schema = load_schema(in_file)
  File "/usr/local/lib/python3.10/site-packages/sgqlc/codegen/schema.py", line 620, in load_schema
    schema = json.load(in_file)
  File "/usr/lib64/python3.10/json/__init__.py", line 293, in load
    return loads(fp.read(),
  File "/usr/lib64/python3.10/json/__init__.py", line 335, in loads
    raise JSONDecodeError("Unexpected UTF-8 BOM (decode using utf-8-sig)",
json.decoder.JSONDecodeError: Unexpected UTF-8 BOM (decode using utf-8-sig): line 1 column 1 (char 0)
```
when opening a UTF file which contains BOM