### PR TITLE
Open all files using encoding='utf-8-sig'

### DIFF
--- a/sgqlc/codegen/operation.py
+++ b/sgqlc/codegen/operation.py
@@ -17,6 +17,7 @@ __docformat__ = 'reStructuredText en'
 
 
 to_python_name = BaseItem._to_python_name
+read_encoding = 'utf-8-sig'  # allows reading UTF-8 with/without BOM
 
 
 def format_graphql_type(typ):
@@ -891,12 +892,14 @@ def add_arguments(ap):
     )
     ap.add_argument(
         'operation.gql',
-        type=argparse.FileType('r'), nargs='*',
+        type=argparse.FileType('r', encoding=read_encoding),
+        nargs='*',
         help='The input GraphQL (DSL) with operations',
         default=[sys.stdin],
     )
     ap.add_argument(
-        '--schema', type=argparse.FileType('r'),
+        '--schema',
+        type=argparse.FileType('r', encoding=read_encoding),
         help=('The input schema as JSON file. '
               'Usually the output from introspection query. '
               'If given, the operations will be validated.'),

--- a/sgqlc/codegen/schema.py
+++ b/sgqlc/codegen/schema.py
@@ -19,6 +19,9 @@ from graphql.language.parser import parse_value as parse_graphql_value
 from graphql.language.visitor import Visitor, visit
 
 
+read_encoding = 'utf-8-sig'  # allows reading UTF-8 with/without BOM
+
+
 # Use Null instead of None as Visitor.leave_* understands None as IDLE,
 # which keeps the original node.
 class Null:
@@ -634,7 +637,9 @@ def load_schema(in_file):
 
 def add_arguments(ap):
     # Generic options to access the GraphQL API
-    ap.add_argument('schema.json', type=argparse.FileType('r'), nargs='?',
+    ap.add_argument('schema.json',
+                    type=argparse.FileType('r', encoding=read_encoding),
+                    nargs='?',
                     help=('The input schema as JSON file. '
                           'Usually the output from introspection query.'),
                     default=sys.stdin)


### PR DESCRIPTION
Otherwise loading UTF-8 files with BOM (Byte order mark) crashes the app.

Thanks to @andreikop

Closes: #190