### PR TITLE
configure actions/setup-python to use cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,13 @@ jobs:
         python-version: ['3.6', '3.7', '3.8', '3.9']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
+        cache: pip
+        cache-dependency-path: dev-requirements.txt
     - name: Install dependencies
       run: |
         python -m pip --quiet --no-input install --upgrade pip wheel


### PR DESCRIPTION
also bump actions/checkout to 3, no major breaks, but it's the latest
version.