### PR TITLE
Removed types sorting

### DIFF
--- a/sgqlc/codegen/schema.py
+++ b/sgqlc/codegen/schema.py
@@ -123,7 +123,7 @@ class CodeGen:
     def __init__(self, schema_name, schema, writer, docstrings):
         self.schema_name = schema_name
         self.schema = schema
-        self.types = sorted(schema['types'], key=lambda x: x['name'])
+        self.types = schema['types']
         self.type_by_name = {t['name']: t for t in self.types}
         self.query_type = self.get_path('queryType', 'name')
         self.mutation_type = self.get_path('mutationType', 'name')


### PR DESCRIPTION
Well, that might be a good idea to sort types in the file but sorting by name creates a mess with dependencies as was found in #189

fixes #189