### PR TITLE
Potential fix for issue 164

### DIFF
--- a/sgqlc/types/__init__.py
+++ b/sgqlc/types/__init__.py
@@ -1944,7 +1944,11 @@ class ContainerType(BaseTypeWithTypename, metaclass=ContainerTypeMeta):
                 return
             self.__fields_cache__[name] = field
 
-        json_value = field.type.__to_json_value__(value)
+        if isinstance(value, list):
+            json_value = [v.__json_data__ for v in value]
+        else:
+            json_value = field.type.__to_json_value__(value)
+
         self.__json_data__[field.graphql_name] = json_value
 
     def __getitem__(self, name):


### PR DESCRIPTION
sgqlc/types/__init__.py:1947
__to_json_value__() may lose information when the underlying type
is generic (e.g., RepositoryOwner), but the values are specific (e.g.,
User)

Example from github looking at a list of forks for a repository:

(Pdb) p self.__json_data__[field.graphql_name]
[{'__typename': 'Repository', 'url': 'https://github.com/ivg/bap', 'owner': {'__typename': 'User', 'url': 'https://github.com/ivg', 'id': 'MDQ6VXNlcjIzMzY2OTg=', 'login': 'ivg', 'company': 'Carnegie Mellon University,  Cylab', 'email': 'ivg@ieee.org', 'twitterUsername': 'ivg_t'}}]
(Pdb) p json_value
[{'url': 'https://github.com/ivg/bap', 'owner': {'id': 'MDQ6VXNlcjIzMzY2OTg=', 'login': 'ivg', 'url': 'https://github.com/ivg', 'email': 'ivg@ieee.org', 'company': 'Carnegie Mellon University,  Cylab', 'twitterUsername': 'ivg_t'}}, {'url': 'https://github.com/maverickwoo/bap', 'owner': {'id': 'MDQ6VXNlcjE3MjY5Mw==', 'login': 'maverickwoo', 'url': 'https://github.com/maverickwoo', 'email': '', 'company': None, 'twitterUsername': None}}]

Note that json_value lost the fact that we knew the owner was a User.
The current code will change it to the generic RepositoryOwner class.

This code very well could be a hack/wrong, but demonstrates the expected
value to get when adding together two repos.

I ran into this with my own code base. I tried to create a minimal example to demo the issue, and attached it here as well.  With the fix, `d['data']['repository']['forks']['nodes'][0].owner` still returns a `RepositoryOwner`, but this allows us
to look at `results` and see the full type of an owner, e.g., `User`.
