### PR TITLE
codegen: sort interfaces first (fixes #189)

### DIFF
--- a/sgqlc/codegen/schema.py
+++ b/sgqlc/codegen/schema.py
@@ -182,9 +182,16 @@ class CodeGen:
     def has_iface(ifaces, name):
         return any(name == iface['name'] for iface in ifaces)
 
+    # all interfaces before anything else.
     # fields without interfaces first, then order the interface
     # implementor after the interface declaration
     def depend_cmp(a, b):
+        if a["kind"] != b["kind"]:
+            if a["kind"] == "INTERFACE":
+                return -1
+            elif b["kind"] == "INTERFACE":
+                return 1
+        
         a_ifaces = a['interfaces']
         b_ifaces = b['interfaces']
         if not a_ifaces and b_ifaces:

--- a/sgqlc/codegen/schema.py
+++ b/sgqlc/codegen/schema.py
@@ -181,17 +181,24 @@ class CodeGen:
     @staticmethod
     def has_iface(ifaces, name):
         return any(name == iface['name'] for iface in ifaces)
-
-    # all interfaces before anything else.
-    # fields without interfaces first, then order the interface
-    # implementor after the interface declaration
-    def depend_cmp(a, b):
+        
+    @staticmethod
+    def is_different_kind(a, b):
         if a["kind"] != b["kind"]:
             if a["kind"] == "INTERFACE":
                 return -1
             elif b["kind"] == "INTERFACE":
                 return 1
-        
+        return None
+
+    # all interfaces before anything else.
+    # fields without interfaces first, then order the interface
+    # implementor after the interface declaration
+    def depend_cmp(a, b):
+        kind_diff = is_different_kind(a, b)
+        if kind_diff is not None:
+            return kind_diff
+
         a_ifaces = a['interfaces']
         b_ifaces = b['interfaces']
         if not a_ifaces and b_ifaces:
@@ -215,7 +222,7 @@ class CodeGen:
             return 1
         else:
             return 0
-
+    
     @staticmethod
     def get_depend_sort_key():
         return functools.cmp_to_key(CodeGen.depend_cmp)


### PR DESCRIPTION
<!-- Open this PR as draft while it is not ready -->

## Description

Fix #189 issue with some interfaces being sorted after their implementing object types.

I believe this is because of the way Python's list sort uses the comparator function (or maybe the comparison key conversion?) -- in my local tests it did not compare every interface to every object type and therefore some objects ended up before their implemented interfaces in the output order.

So this PR just ensures that interfaces are sorted strictly before anything else. Two interfaces or two objects fall through to the existing comparison function.

<!-- Describe your solution for the issue here. Adding videos, screenshots and expected logs may help the others to understand what is new.
-->

## Related Issues
<!--
Use keywords like 'close' or 'solves' to link this PR to an issue.
For example:

Closes #12345
Unblocks #54321
-->

Fixes #189, at least my case of the same issue.

### Pull request checklist

<!-- Before submitting the PR, please address each item -->

- [ ] **Tests**: This PR includes tests for covering the features or bug fixes (if applicable).
- ~[ ] **Docs**: This PR updates/creates the necessary documentation.~ unneeded?
- [ ] **Commits descriptions**: All commits in this PR contain a title and description according to [CONTRIBUTING.md](https://github.com/profusion/quickstart-nodejs-rest/blob/master/doc/CONTRIBUTING.md#commits).

<!-- Also, don't forget to review your code before marking it as ready to merge -->

## How to test it

Someone might pull and test the data hub API? maybe that can be added as a test?

## Change logs

not sure what to do here?