### PR TITLE
add: --exclude-default-types and --add-scalar-imports arguments to schema codegen

### DIFF
--- a/sgqlc/codegen/schema.py
+++ b/sgqlc/codegen/schema.py
@@ -662,7 +662,8 @@ def load_schema(in_file):
             'schema must be introspection object or query result')
 
 
-scalar_import_arg_re = re.compile('^([A-Za-z_]+[A-Za-z0-9_]*)=([A-Za-z0-9_.]*)$')
+scalar_import_arg_re = re.compile(
+    '^([A-Za-z_]+[A-Za-z0-9_]*)=([A-Za-z0-9_.]*)$')
 
 
 def parse_scalar_import(s):
@@ -702,8 +703,8 @@ def add_arguments(ap):
                     default=[])
     ap.add_argument('--add-scalar-imports', nargs='+',
                     help=('Specify "ScalarName=import.file" to automatically '
-                          'import "ScalarName" whenever this scalar is used in '
-                          'the schema'),
+                          'import "ScalarName" whenever this scalar is used '
+                          'in the schema'),
                     type=parse_scalar_import,
                     default=[])
 

--- a/sgqlc/codegen/schema.py
+++ b/sgqlc/codegen/schema.py
@@ -119,8 +119,25 @@ def graphql_type_to_str(t):
         return t['name']
 
 
+builtin_types_import = 'sgqlc.types'
+builtin_scalar_imports = {
+    k: builtin_types_import
+    for k in ('Int', 'Float', 'String', 'Boolean', 'ID')
+}
+datetime_scalar_imports = {
+    k: 'sgqlc.types.datetime' for k in ('DateTime', 'Date', 'Time')
+}
+relay_imports = {
+    k: 'sgqlc.types.relay' for k in ('Node', 'PageInfo')
+}
+
+default_type_imports = {**builtin_scalar_imports, **datetime_scalar_imports,
+                        **relay_imports}
+
+
 class CodeGen:
-    def __init__(self, schema_name, schema, writer, docstrings):
+    def __init__(self, schema_name, schema, writer, docstrings,
+                 type_imports=default_type_imports):
         self.schema_name = schema_name
         self.schema = schema
         self.types = sorted(schema['types'], key=lambda x: x['name'])
@@ -129,7 +146,10 @@ class CodeGen:
         self.mutation_type = self.get_path('mutationType', 'name')
         self.subscription_type = self.get_path('subscriptionType', 'name')
         self.directives = schema.get('directives', [])
+        self.type_imports = type_imports
+        self.imports = set()
         self.analyze()
+        self.uses_relay = 'sgqlc.types.relay' in self.imports
         self.writer = writer
         self.written_types = set()
         self.docstrings = docstrings
@@ -144,23 +164,17 @@ class CodeGen:
             return fallback
         return d
 
-    builtin_types = ('Int', 'Float', 'String', 'Boolean', 'ID')
-    datetime_types = ('DateTime', 'Date', 'Time')
-    relay_types = ('Node', 'PageInfo')
-
     def analyze(self):
-        self.uses_datetime = False
-        self.uses_relay = False
         for t in self.types:
             name = t['name']
-            if name in self.datetime_types:
-                self.uses_datetime = True
-                if self.uses_relay:
-                    break
-            elif name in self.relay_types:
-                self.uses_relay = True
-                if self.uses_datetime:
-                    break
+            try:
+                self.imports.add(self.type_imports[name])
+            except KeyError:
+                pass
+        try:
+            self.imports.remove(builtin_types_import)
+        except KeyError:
+            pass
 
     def write(self):
         self.write_header()
@@ -523,10 +537,9 @@ class %(name)s(%(bases)s):
 
     def write_type_scalar(self, t):
         name = t['name']
-        if name in self.builtin_types:
-            self.writer('%(name)s = sgqlc.types.%(name)s' % t)
-        elif name in self.datetime_types:
-            self.writer('%(name)s = sgqlc.types.datetime.%(name)s' % t)
+        imp = self.type_imports.get(name)
+        if imp:
+            self.writer('%s = %s.%s' % (name, imp, name))
         else:
             self.writer('''\
 class %(name)s(sgqlc.types.Scalar):
@@ -562,22 +575,12 @@ class %(name)s(sgqlc.types.Union):
 
     def write_header(self):
         self.writer('import sgqlc.types\n')
-        self.write_datetime_import()
-        self.write_relay_import()
+        for imp in sorted(self.imports):
+            self.writer('import %s\n' % imp)
         self.writer('\n\n%s = sgqlc.types.Schema()\n\n\n' % self.schema_name)
         self.write_relay_fixup()
         if self.docstrings:
             self.writer('__docformat__ = \'markdown\'\n\n')
-
-    def write_datetime_import(self):
-        if not self.uses_datetime:
-            return
-        self.writer('import sgqlc.types.datetime\n')
-
-    def write_relay_import(self):
-        if not self.uses_relay:
-            return
-        self.writer('import sgqlc.types.relay\n')
 
     def write_relay_fixup(self):
         if not self.uses_relay:
@@ -684,6 +687,10 @@ def add_arguments(ap):
                     help=('Include schema descriptions in the generated file '
                           'as docstrings'),
                     default=False)
+    ap.add_argument('--exclude-default-types', nargs='+',
+                    choices=['Time', 'Date', 'DateTime'],
+                    help='Exclude the use of sgqlc types in generated client',
+                    default=[])
 
 
 def handle_command(parsed_args):
@@ -705,8 +712,13 @@ def handle_command(parsed_args):
     schema = load_schema(in_file)
 
     docstrings = args['docstrings'] or False
+    exclude_default_types = args['exclude_default_types'] or []
 
-    gen = CodeGen(schema_name, schema, out_file.write, docstrings)
+    for k in exclude_default_types:
+        default_type_imports.pop(k)
+
+    gen = CodeGen(schema_name, schema, out_file.write, docstrings,
+                  default_type_imports)
     gen.write()
     out_file.close()
 


### PR DESCRIPTION
## Description

We are testing Golang services that use the library https://github.com/99designs/gqlgen to generate the code. This library also uses a custom scalar Time type, but, unlike the sgqlc library, in it the Time type is a complete representation of the timestamp.

With the current changes, it is proposed to add:
--exclude-default-types argument to the client generation utility, which provides the ability to deactivate the use of default types in the generated client;
--add-scalar-imports argument to the client generation utility, which provides the ability to import the use of custom scalar types in the generated client.

### Pull request checklist

<!-- Before submitting the PR, please address each item -->

- [x] **Tests**: This PR includes tests for covering the features or bug fixes (if applicable).
- [x] **Docs**: This PR updates/creates the necessary documentation.
- [x] **CI**: Make sure your Pull Request passes all CI checks. If not, clarify the motif behind that and the action plan to solve it (may reference a ticket)

## How to test it

use `sgqlc-codegen schema -d schema.json --exclude-default-types Time Date DateTimes` command with `--exclude-default-types` argument

## Visual reference

with argument in command
```python
class Time(sgqlc.types.Scalar):
    __schema__ = schema
```

without argument in command
```python
Time = sgqlc.types.datetime.Time
```
