### PR TITLE
Don't close user-provided requests sessions

### DIFF
--- a/sgqlc/endpoint/requests.py
+++ b/sgqlc/endpoint/requests.py
@@ -110,7 +110,7 @@ class RequestsEndpoint(BaseEndpoint):
         self.method = method
         self.auth = auth
         self.session = session or requests.Session()
-        self.close_session = session is not None
+        self.close_session = session is None
 
     def __del__(self):
         # keep the session open if it has been provided by the user

--- a/tests/test-endpoint-requests.py
+++ b/tests/test-endpoint-requests.py
@@ -216,7 +216,7 @@ def test_basic(mock_requests_send):
         'RequestsEndpoint('
         + 'url={}, '.format(test_url)
         + 'base_headers={}, timeout=None, method=POST, auth=None, '
-        + 'session=None)')
+        + 'session=<class \'requests.sessions.Session\'>)')
 
 
 @patch('requests.sessions.Session.send')
@@ -236,7 +236,7 @@ def test_basic_auth(mock_requests_send):
         + 'url={}, '.format(test_url)
         + 'base_headers={}, timeout=None, method=POST, '
         + 'auth=<class \'requests.auth.HTTPBasicAuth\'>, '
-        + 'session=None)')
+        + 'session=<class \'requests.sessions.Session\'>)')
 
 
 @patch('requests.sessions.Session.send')
@@ -439,7 +439,8 @@ def test_get(mock_requests_send):
         'RequestsEndpoint('
         + 'url={}, '.format(test_url)
         + 'base_headers={}, '.format(base_headers)
-        + 'timeout=None, method=GET, auth=None, session=None)',
+        + 'timeout=None, method=GET, auth=None, '
+        + 'session=<class \'requests.sessions.Session\'>)',
         )
 
 


### PR DESCRIPTION
<!-- Open this PR as draft while it is not ready -->

## Description

If the user has provided a requests session in the RequestsEndpoint constructor, it will not be closed after each request anymore.

If no session was provided, one will be created in the constructor and closed in the destructor.

## Related Issues
Closes #225

<!-- Also, don't forget to review your code before marking it as ready to merge -->

### Pull request checklist

<!-- Before submitting the PR, please address each item -->

- [ ] **Tests**: This PR includes tests for covering the features or bug fixes (if applicable).
- [x] **Docs**: This PR updates/creates the necessary documentation.
- [ ] **CI**: Make sure your Pull Request passes all CI checks. If not, clarify the motif behind that and the action plan to solve it (may reference a ticket)

## How to test it

Change the Github Agile Dashboard example the following way

1. Replace the HTTPEndpoint with a RequestsEndpoint
2. Enable debug logging, especially for the `urllib3.connectionpool` logger
3. Check the log for "Starting new HTTPS connection" - it should only appear once