### PR TITLE
Expose headers in endpoint data object

### DIFF
--- a/sgqlc/endpoint/requests.py
+++ b/sgqlc/endpoint/requests.py
@@ -57,6 +57,8 @@ class RequestsEndpoint(BaseEndpoint):
     :data: object matching the GraphQL requests, or ``null`` if only
        errors were returned.
 
+    :headers: dictionary of HTTP response headers.
+
     :errors: list of errors, which are objects with the key "message" and
        optionally others, such as "location" (for errors matching GraphQL
        input). Instead of raising exceptions, such as
@@ -198,8 +200,10 @@ class RequestsEndpoint(BaseEndpoint):
         :type timeout: float
 
         :return: dict with optional fields ``data`` containing the GraphQL
-          returned data as nested dict and ``errors`` with an array of
-          errors. Note that both ``data`` and ``errors`` may be returned!
+          returned data as nested dict, ``headers`` with a dictionary of
+          response headers with lower-cased keys, and ``errors`` with an
+          array of errors. Note that both ``data`` and ``errors`` may be
+          returned!
         :rtype: dict
         '''
         query, req = self._prepare(
@@ -219,6 +223,8 @@ class RequestsEndpoint(BaseEndpoint):
                 try:
                     f.raise_for_status()
                     data = f.json()
+                    if data:
+                        data['headers'] = dict(f.headers)
                     if data and data.get('errors'):
                         return self._log_graphql_error(query, data)
                     return data

--- a/tests/test-endpoint-http.py
+++ b/tests/test-endpoint-http.py
@@ -3,7 +3,7 @@ import json
 import urllib.error
 import urllib.request
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 from sgqlc.endpoint.http import HTTPEndpoint, add_query_to_url
 from sgqlc.types import Schema, Type
 from sgqlc.operation import Operation
@@ -30,8 +30,17 @@ query GitHubRepoIssues($repoOwner: String!, $repoName: String!) {
 }
 '''
 
+graphql_headers_ok = {
+    'Content-Type': 'application/json; charset=utf8',
+    'X-Ratelimit-Limit': '1000',
+}
+
 graphql_response_ok = b'''
 {
+  "headers": {
+    "Content-Type": "application/json; charset=utf8",
+    "X-Ratelimit-Limit": "1000"
+  },
   "data": {
     "repository": {
       "issues": {
@@ -48,6 +57,10 @@ graphql_response_ok = b'''
 
 graphql_response_error = b'''
 {
+  "headers": {
+    "Content-Type": "application/json; charset=utf8",
+    "X-Ratelimit-Limit": "1000"
+  },
   "errors": [{
     "message": "Server Reported Error",
     "locations": [{"line": 1, "column": 1}]
@@ -74,11 +87,15 @@ def get_json_exception(s):
         return e
 
 
-def configure_mock_urlopen(mock_urlopen, payload):
+def configure_mock_urlopen(mock_urlopen, payload, headers):
     if isinstance(payload, Exception):
         mock_urlopen.side_effect = payload
     else:
-        mock_urlopen.return_value = io.BytesIO(payload)
+        res = MagicMock()
+        res.__enter__.return_value = res
+        res.headers = headers
+        res.read.return_value = payload
+        mock_urlopen.return_value = res
 
 
 def check_request_url(req, expected):
@@ -192,7 +209,9 @@ def check_mock_urlopen(
 def test_basic(mock_urlopen):
     'Test if basic usage with only essential parameters works'
 
-    configure_mock_urlopen(mock_urlopen, graphql_response_ok)
+    configure_mock_urlopen(
+        mock_urlopen, graphql_response_ok, graphql_headers_ok
+    )
 
     endpoint = HTTPEndpoint(test_url)
     data = endpoint(graphql_query)
@@ -208,7 +227,9 @@ def test_basic(mock_urlopen):
 def test_basic_bytes_query(mock_urlopen):
     'Test if query with type bytes works'
 
-    configure_mock_urlopen(mock_urlopen, graphql_response_ok)
+    configure_mock_urlopen(
+        mock_urlopen, graphql_response_ok, graphql_headers_ok
+    )
 
     endpoint = HTTPEndpoint(test_url)
     data = endpoint(graphql_query.encode('utf-8'))
@@ -220,7 +241,9 @@ def test_basic_bytes_query(mock_urlopen):
 def test_basic_operation_query(mock_urlopen):
     'Test if query with type sgqlc.operation.Operation() works'
 
-    configure_mock_urlopen(mock_urlopen, graphql_response_ok)
+    configure_mock_urlopen(
+        mock_urlopen, graphql_response_ok, graphql_headers_ok
+    )
 
     schema = Schema()
 
@@ -252,7 +275,9 @@ def test_basic_operation_query(mock_urlopen):
 def test_headers(mock_urlopen):
     'Test if all headers are passed'
 
-    configure_mock_urlopen(mock_urlopen, graphql_response_ok)
+    configure_mock_urlopen(
+        mock_urlopen, graphql_response_ok, graphql_headers_ok
+    )
 
     base_headers = {
         'Xpto': 'abc',
@@ -274,7 +299,9 @@ def test_headers(mock_urlopen):
 def test_default_timeout(mock_urlopen):
     'Test if default timeout is respected'
 
-    configure_mock_urlopen(mock_urlopen, graphql_response_ok)
+    configure_mock_urlopen(
+        mock_urlopen, graphql_response_ok, graphql_headers_ok
+    )
 
     timeout = 123
 
@@ -288,7 +315,9 @@ def test_default_timeout(mock_urlopen):
 def test_call_timeout(mock_urlopen):
     'Test if call timeout takes precedence over default'
 
-    configure_mock_urlopen(mock_urlopen, graphql_response_ok)
+    configure_mock_urlopen(
+        mock_urlopen, graphql_response_ok, graphql_headers_ok
+    )
 
     timeout = 123
 
@@ -302,7 +331,9 @@ def test_call_timeout(mock_urlopen):
 def test_variables(mock_urlopen):
     'Test if variables are passed to server'
 
-    configure_mock_urlopen(mock_urlopen, graphql_response_ok)
+    configure_mock_urlopen(
+        mock_urlopen, graphql_response_ok, graphql_headers_ok
+    )
 
     variables = {'repoOwner': 'owner', 'repoName': 'name'}
 
@@ -316,7 +347,9 @@ def test_variables(mock_urlopen):
 def test_operation_name(mock_urlopen):
     'Test if operation name is passed to server'
 
-    configure_mock_urlopen(mock_urlopen, graphql_response_ok)
+    configure_mock_urlopen(
+        mock_urlopen, graphql_response_ok, graphql_headers_ok
+    )
 
     operation_name = 'xpto'
 
@@ -330,7 +363,9 @@ def test_operation_name(mock_urlopen):
 def test_json_error(mock_urlopen):
     'Test if broken server responses (invalid JSON) is handled'
 
-    configure_mock_urlopen(mock_urlopen, graphql_response_json_error)
+    configure_mock_urlopen(
+        mock_urlopen, graphql_response_json_error, graphql_headers_ok
+    )
 
     endpoint = HTTPEndpoint(test_url)
     data = endpoint(graphql_query)
@@ -357,7 +392,9 @@ def test_json_error(mock_urlopen):
 def test_get(mock_urlopen):
     'Test if HTTP method GET request works'
 
-    configure_mock_urlopen(mock_urlopen, graphql_response_ok)
+    configure_mock_urlopen(
+        mock_urlopen, graphql_response_ok, graphql_headers_ok
+    )
 
     base_headers = {
         'Xpto': 'abc',
@@ -396,7 +433,9 @@ def test_get(mock_urlopen):
 def test_server_reported_error(mock_urlopen):
     'Test if GraphQL errors reported with HTTP 200 is handled properly'
 
-    configure_mock_urlopen(mock_urlopen, graphql_response_error)
+    configure_mock_urlopen(
+        mock_urlopen, graphql_response_error, graphql_headers_ok
+    )
 
     endpoint = HTTPEndpoint(test_url)
     data = endpoint(graphql_query)
@@ -415,7 +454,7 @@ def test_server_http_error(mock_urlopen):
         {'Xpto': 'abc'},
         io.BytesIO(b'xpto'),
     )
-    configure_mock_urlopen(mock_urlopen, err)
+    configure_mock_urlopen(mock_urlopen, err, graphql_headers_ok)
 
     endpoint = HTTPEndpoint(test_url)
     data = endpoint(graphql_query)
@@ -445,7 +484,7 @@ def test_server_http_non_conforming_json(mock_urlopen):
         {'Content-Type': 'application/json'},
         io.BytesIO(b'{"message": "xpto"}'),
     )
-    configure_mock_urlopen(mock_urlopen, err)
+    configure_mock_urlopen(mock_urlopen, err, graphql_headers_ok)
 
     endpoint = HTTPEndpoint(test_url)
     data = endpoint(graphql_query)
@@ -475,7 +514,7 @@ def test_server_error_broken_json(mock_urlopen):
         {'Content-Type': 'application/json'},
         io.BytesIO(b'xpto'),
     )
-    configure_mock_urlopen(mock_urlopen, err)
+    configure_mock_urlopen(mock_urlopen, err, graphql_headers_ok)
 
     endpoint = HTTPEndpoint(test_url)
     data = endpoint(graphql_query)
@@ -507,7 +546,7 @@ def test_server_http_graphql_error(mock_urlopen):
         {'Content-Type': 'application/json'},
         io.BytesIO(graphql_response_error),
     )
-    configure_mock_urlopen(mock_urlopen, err)
+    configure_mock_urlopen(mock_urlopen, err, graphql_headers_ok)
 
     endpoint = HTTPEndpoint(test_url)
     data = endpoint(graphql_query)
@@ -536,7 +575,7 @@ def test_server_http_single_error(mock_urlopen):
         {'Content-Type': 'application/json'},
         io.BytesIO(b'{"errors": "a string"}'),
     )
-    configure_mock_urlopen(mock_urlopen, err)
+    configure_mock_urlopen(mock_urlopen, err, graphql_headers_ok)
 
     endpoint = HTTPEndpoint(test_url)
     data = endpoint(graphql_query)
@@ -565,7 +604,7 @@ def test_server_http_error_string_list(mock_urlopen):
         {'Content-Type': 'application/json'},
         io.BytesIO(b'{"errors": ["a", "b"]}'),
     )
-    configure_mock_urlopen(mock_urlopen, err)
+    configure_mock_urlopen(mock_urlopen, err, graphql_headers_ok)
 
     endpoint = HTTPEndpoint(test_url)
     data = endpoint(graphql_query)
@@ -594,7 +633,7 @@ def test_server_http_error_list_message(mock_urlopen):
         {'Content-Type': 'application/json'},
         io.BytesIO(b'{"errors": [{"message": [1, 2]}]}'),
     )
-    configure_mock_urlopen(mock_urlopen, err)
+    configure_mock_urlopen(mock_urlopen, err, graphql_headers_ok)
 
     endpoint = HTTPEndpoint(test_url)
     data = endpoint(graphql_query)

--- a/tests/test-endpoint-requests.py
+++ b/tests/test-endpoint-requests.py
@@ -13,6 +13,10 @@ class MockResponse:
     def __init__(self, json_data, status_code):
         self.json_data = json_data
         self.status_code = status_code
+        self.headers = {
+            'content-type': 'application/json; charset=utf8',
+            'x-ratelimit-limit': '1000',
+        }
         self.text = json_data
 
     def __enter__(self):
@@ -52,6 +56,10 @@ query GitHubRepoIssues($repoOwner: String!, $repoName: String!) {
 
 graphql_response_ok = '''
 {
+  "headers": {
+    "content-type": "application/json; charset=utf8",
+    "x-ratelimit-limit": "1000"
+  },
   "data": {
     "repository": {
       "issues": {
@@ -68,6 +76,10 @@ graphql_response_ok = '''
 
 graphql_response_error = '''
 {
+  "headers": {
+    "content-type": "application/json; charset=utf8",
+    "x-ratelimit-limit": "1000"
+  },
   "errors": [{
     "message": "Server Reported Error",
     "locations": [{"line": 1, "column": 1}]


### PR DESCRIPTION
## Description

<!-- Describe what your PR does here, change log, etc -->

When accessing many services' GraphQL servers, the server will alert the client to rate limits and other warnings by adding HTTP headers to the response.

For example, GitHub uses the x-ratelimit-limit, x-ratelimit-remaining, x-ratelimit-used, x-ratelimit-reset and x-ratelimit-resource headers, as well as the retry-after header, to indicate to the client when to back off on requests.

See, for example:
https://docs.github.com/en/graphql/overview/rate-limits-and-node-limits-for-the-graphql-api
https://developer.atlassian.com/cloud/jira/platform/rate-limiting/

This PR exposes these (indeed, all HTTP) headers to the caller, at the same level as any error codes, so that the endpoint caller can detect the necessary headers for the service which they're querying, and adjust their query rate.

### Pull request checklist

<!-- Before submitting the PR, please address each item -->

- [x] **Tests**: This PR includes tests for covering the features or bug fixes (if applicable).
- [x] **Docs**: This PR updates/creates the necessary documentation.
- [ ] **CI**: Make sure your Pull Request passes all CI checks. If not, clarify the motif behind that and the action plan to solve it (may reference a ticket)

## How to test it

<!-- Describe how the reviewers can test your feature. -->

The returned data object now contains a "header" attribute, which can be read in order to discover servers' rate limit headers.

Changing 
```
data = endpoint(query, variables=variables)
```
to
```
while True:
    data = endpoint(query, variables=variables)

    if "headers" in data and h := data["headers"]:
        if "x-ratelimit-remaining" in h and int(h["x-ratelimit-remaining"]) < 20:
            # GitHub rate limits
            if "x-ratelimit-reset" in h:
                reset_time = int(h["x-ratelimit-reset"])
                time.sleep(reset_time)
                continue
            # Jira rate limits
            elif "retry-after" in h:
                reset_time = int(h["retry-after"])
                time.sleep(reset_time)
                continue
    return data
```
... and running against GitHub or Jira's GraphQL endpoints should enact the rate limits.