### PR TITLE
Let httpx transport errors fall through to caller

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -160,7 +160,7 @@ version = "0.4.6"
 description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
-groups = ["dev", "docs"]
+groups = ["main", "dev", "docs"]
 markers = "sys_platform == \"win32\""
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
@@ -418,7 +418,7 @@ version = "2.1.0"
 description = "brain-dead simple config-ini parsing"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760"},
     {file = "iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7"},
@@ -518,7 +518,7 @@ version = "25.0"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev", "docs"]
+groups = ["main", "dev", "docs"]
 files = [
     {file = "packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484"},
     {file = "packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f"},
@@ -530,7 +530,7 @@ version = "1.5.0"
 description = "plugin and hook calling mechanisms for python"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669"},
     {file = "pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1"},
@@ -561,7 +561,7 @@ version = "8.3.5"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820"},
     {file = "pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845"},
@@ -845,8 +845,7 @@ version = "2.2.1"
 description = "A lil' TOML parser"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
-markers = "python_full_version <= \"3.11.0a6\""
+groups = ["main", "dev"]
 files = [
     {file = "tomli-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678e4fa69e4575eb77d103de3df8a895e1591b48e740211bd1067378c69e8249"},
     {file = "tomli-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:023aa114dd824ade0100497eb2318602af309e5a55595f76b626d6d9f3b7b0a6"},
@@ -881,6 +880,7 @@ files = [
     {file = "tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc"},
     {file = "tomli-2.2.1.tar.gz", hash = "sha256:cd45e1dc79c835ce60f7404ec8119f2eb06d38b1deba146f07ced3bbc44505ff"},
 ]
+markers = {main = "python_version < \"3.11\"", dev = "python_full_version <= \"3.11.0a6\""}
 
 [[package]]
 name = "typing-extensions"
@@ -953,10 +953,11 @@ type = ["pytest-mypy"]
 
 [extras]
 httpx = ["httpx"]
+pytest = ["pytest"]
 requests = ["requests"]
 websocket = ["websocket-client"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.8,<4"
-content-hash = "ec147ad7f07a33b6eb9eec393771c1c15168f617f17f20aa52e6d2e0440bc6d8"
+content-hash = "7a3763fb3135e478b9951f2fece53b9c7daf5de46cf14fbee1677dad408dd321"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ sgqlc-codegen = 'sgqlc.codegen:main'
 websocket = ['websocket-client']
 requests = ['requests']
 httpx = ['httpx']
+pytest = ['pytest']
 
 [tool.poetry.group.dev.dependencies]
 pytest = '*'

--- a/sgqlc/endpoint/httpx.py
+++ b/sgqlc/endpoint/httpx.py
@@ -160,7 +160,7 @@ class HTTPXEndpoint(HTTPEndpoint):
             try:
                 response = self.client.send(req)
                 return self._parse_httpx_response(query, response)
-            except httpx.HTTPError as exc:
+            except httpx.HTTPStatusError as exc:
                 return self._log_httpx_error(query, req, exc)
 
     def _parse_httpx_response(self, query, response):

--- a/tests/test-endpoint-httpx.py
+++ b/tests/test-endpoint-httpx.py
@@ -1,6 +1,7 @@
 import json
 
 import httpx
+import pytest
 
 from sgqlc.endpoint.httpx import HTTPXEndpoint
 from sgqlc.types import Schema, Type
@@ -548,6 +549,21 @@ def test_server_http_non_conforming_json(respx_mock):
         ],
         'data': None,
     }
+    check_respx_route(route)
+
+
+def test_server_http_transport_error(respx_mock):
+    'Test if a transport error will get passed back to the caller'
+
+    route = respx_mock.route(name='graphql', method='POST', url=test_url).mock(
+        side_effect=httpx.RemoteProtocolError
+    )
+
+    endpoint = HTTPXEndpoint(test_url)
+
+    with pytest.raises(httpx.RemoteProtocolError):
+        endpoint(graphql_query)
+
     check_respx_route(route)
 
 


### PR DESCRIPTION
Fixes #261

I needed to add pytest to optional depdendencies since flake8-requirements will prefer PEP621 over poetry's groups and apparently PEP 735 is not yet supported. I get `I900 'pytest' not listed as a requirement` otherwise.

https://github.com/arkq/flake8-requirements/blob/30242fe4b86730b69816e2d4e0ac2b74894b6381/src/flake8_requirements/checker.py#L743

Please see open question in #261 but I wanted to get this off my chest in case this is your preferred solution